### PR TITLE
Problem: unwinding across FFI is theoretically UB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://github.com/getditto/safer_ffi)
 
 </span>
 
-# What is `safer_ffi`? 
+# What is `safer_ffi`?
 
 `safer_ffi` is a framework that helps you write foreign function interfaces (FFI) without polluting your Rust code with `unsafe { ... }` code blocks while making functions far easier to read and maintain.
 

--- a/ffi_tests/generated.h
+++ b/ffi_tests/generated.h
@@ -14,31 +14,13 @@
 extern "C" {
 #endif
 
-
-#include <stddef.h>
-#include <stdint.h>
-
-/** \remark Has the same ABI as `uint8_t` **/
-#ifdef DOXYGEN
-typedef enum Bar
-#else
-typedef uint8_t Bar_t; enum
-#endif
-{
-    /** . */
-    BAR_A,
-}
-#ifdef DOXYGEN
-Bar_t
-#endif
-;
-
-void check_bar (
-    Bar_t _bar);
-
 typedef struct foo foo_t;
 
 foo_t * new_foo (void);
+
+
+#include <stddef.h>
+#include <stdint.h>
 
 int32_t read_foo (
     foo_t const * foo);
@@ -117,6 +99,24 @@ typedef struct {
  */
 int32_t const * max (
     slice_ref_int32_t xs);
+
+/** \remark Has the same ABI as `uint8_t` **/
+#ifdef DOXYGEN
+typedef enum Bar
+#else
+typedef uint8_t Bar_t; enum
+#endif
+{
+    /** . */
+    BAR_A,
+}
+#ifdef DOXYGEN
+Bar_t
+#endif
+;
+
+void check_bar (
+    Bar_t _bar);
 
 
 #ifdef __cplusplus

--- a/src/_lib.rs
+++ b/src/_lib.rs
@@ -246,3 +246,42 @@ mod prelude {
 macro_rules! NULL {() => (
     $crate::core::ptr::null_mut()
 )}
+
+#[cfg(feature = "log")]
+#[doc(hidden)]
+pub use ::log;
+
+#[allow(missing_copy_implementations, missing_debug_implementations)]
+#[doc(hidden)] /** Not part of the public API **/ pub
+struct __PanicOnDrop__; impl Drop for __PanicOnDrop__ {
+    fn drop (self: &'_ mut Self)
+    {
+        panic!()
+    }
+}
+
+#[cfg(feature = "log")]
+#[doc(hidden)] /** Not part of the public API **/ #[macro_export]
+macro_rules! __abort_with_msg__ { ($($tt:tt)*) => ({
+    $crate::log::error!($($tt)*);
+    let _panic_on_drop = $crate::__PanicOnDrop__;
+    $crate::core::panic!($($tt)*);
+})}
+#[cfg(all(
+    not(feature = "log"),
+    feature = "std",
+))]
+#[doc(hidden)] /** Not part of the public API **/ #[macro_export]
+macro_rules! __abort_with_msg__ { ($($tt:tt)*) => ({
+    $crate::std::eprintln!($($tt)*);
+    $crate::std::process::abort();
+})}
+#[cfg(all(
+    not(feature = "log"),
+    not(feature = "std"),
+))]
+#[doc(hidden)] /** Not part of the public API **/ #[macro_export]
+macro_rules! __abort_with_msg__ { ($($tt:tt)*) => ({
+    let _panic_on_drop = $crate::__PanicOnDrop__;
+    $crate::core::panic!($($tt)*);
+})}

--- a/src/ffi_export.rs
+++ b/src/ffi_export.rs
@@ -46,7 +46,7 @@ macro_rules! __ffi_export__ {(
         where
             $( $($bounds)* )?
         {{
-            // let body = #[inline(always)] || {
+            let body = /* #[inline(always)] */ || {
                 $(
                     {
                         fn __return_type__<T> (_: T)
@@ -86,29 +86,29 @@ macro_rules! __ffi_export__ {(
                     };
                 )*
                 $body
-            // };
-            // let guard = {
-            //     struct $fname;
-            //     impl $crate::core::ops::Drop
-            //         for $fname
-            //     {
-            //         fn drop (self: &'_ mut Self)
-            //         {
-            //             $crate::core::panic!($crate::core::concat!(
-            //                 "Error, attempted to panic across the FFI ",
-            //                 "boundary of `",
-            //                 $crate::core::stringify!($fname),
-            //                 "()`, ",
-            //                 "which is Undefined Behavior.\n",
-            //                 "Aborting for soundness.",
-            //             ));
-            //         }
-            //     }
-            //     $fname
-            // };
-            // let ret = body();
-            // $crate::core::mem::forget(guard);
-            // ret
+            };
+            let guard = {
+                struct $fname;
+                impl $crate::core::ops::Drop
+                    for $fname
+                {
+                    fn drop (self: &'_ mut Self)
+                    {
+                        $crate::__abort_with_msg__!($crate::core::concat!(
+                            "Error, attempted to panic across the FFI ",
+                            "boundary of `",
+                            $crate::core::stringify!($fname),
+                            "()`, ",
+                            "which is Undefined Behavior.\n",
+                            "Aborting for soundness.",
+                        ));
+                    }
+                }
+                $fname
+            };
+            let ret = body();
+            $crate::core::mem::forget(guard);
+            ret
         }}
     };
 

--- a/tests/layout_macros.rs
+++ b/tests/layout_macros.rs
@@ -195,15 +195,15 @@ fn test_max ()
     }
 }
 
-#[cfg(debug_assertions)]
-#[test]
-#[should_panic]
-fn test_max_invalid ()
-{
-    unsafe {
-        ffi_max(i32_slice { ptr: 0 as _, len: 0 });
-    }
-}
+// #[cfg(debug_assertions)]
+// #[test]
+// #[should_panic] /* Currently abort guard prevents it */
+// fn test_max_invalid ()
+// {
+//     unsafe {
+//         ffi_max(i32_slice { ptr: 0 as _, len: 0 });
+//     }
+// }
 
 #[ffi_export]
 /// Returns an owned copy of the input array, with its elements sorted.


### PR DESCRIPTION
Solution: set up an abort-on-drop guard to prevent ever reaching the FFI
boundary when unwinding.

Remarks:

  - Although theoretically UB, as of version 1.43.0, the behavior is temporarily
    defined as one that aborts, so no real change here.

    Nevertheless, the unwind-ffi WG is working on defining the behavior for some cases,
    which could lead to UB for the other cases. So better safe than sorry.