### PR TITLE
Fix readme rust code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ use ::safer_ffi::prelude::*;
 #[derive_ReprC]
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
-pub
-struct Point {
+pub struct Point {
     x: f64,
     y: f64,
 }
@@ -72,11 +71,7 @@ struct Point {
 /* Export a Rust function to the C world. */
 /// Returns the middle point of `[a, b]`.
 #[ffi_export]
-fn mid_point (
-    a: &Point,
-    b: &Point,
-) -> Point
-{
+fn mid_point(a: &Point, b: &Point) -> Point {
     Point {
         x: (a.x + b.x) / 2.,
         y: (a.y + b.y) / 2.,
@@ -85,16 +80,14 @@ fn mid_point (
 
 /// Pretty-prints a point using Rust's formatting logic.
 #[ffi_export]
-fn print_point (point: &Point)
-{
+fn print_point(point: &Point) {
     println!("{:?}", point);
 }
 
 /// The following test function is necessary for the header generation.
 #[::safer_ffi::cfg_headers]
 #[test]
-fn generate_headers () -> ::std::io::Result<()>
-{
+fn generate_headers() -> ::std::io::Result<()> {
     ::safer_ffi::headers::builder()
         .to_file("rust_points.h")?
         .generate()


### PR DESCRIPTION
Use a format how rustfmt would format for readability.