### PR TITLE
Fix misinteraction between `#[derive_ReprC]` & other macros (such as serde)

### DIFF
--- a/src/layout/macros.rs
+++ b/src/layout/macros.rs
@@ -385,7 +385,7 @@ macro_rules! ReprC {
                         )?
                     } {
                         $(
-                            $(#[$($field_meta)*])*
+                            // $(#[$($field_meta)*])*
                             pub
                             $field_name :
                                 <$field_ty as $crate::layout::ReprC>::CLayout


### PR DESCRIPTION
Fixes #35