### PR TITLE
[Node.js] Added support for the `nodejs(async_worker)` parameter,

### DIFF
--- a/nodejs_tests/Cargo.toml
+++ b/nodejs_tests/Cargo.toml
@@ -7,8 +7,13 @@ version = "0.1.0"
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2018"
 
-[dependencies]
-safer-ffi = { path = "..", features = ["proc_macros", "out-refs"] }
+[dependencies.safer-ffi]
+path = ".."
+features = [
+    # "debug_proc_macros",
+    "proc_macros",
+    "out-refs",
+]
 
 [build-dependencies]
 safer-ffi-build = { path = "../safer-ffi-build" }

--- a/nodejs_tests/src/lib.rs
+++ b/nodejs_tests/src/lib.rs
@@ -20,7 +20,8 @@ pub
 struct Foo { opaque: i32 }
 
 #[ffi_export(node_js)]
-fn foo_new () -> repr_c::Box<Foo>
+fn foo_new ()
+  -> repr_c::Box<Foo>
 {
     Box::new(Foo { opaque: 42 })
         .into()
@@ -65,7 +66,8 @@ fn concat_bytes (
 })}
 
 #[ffi_export(node_js)]
-fn get_hello() -> char_p::Box
+fn get_hello ()
+  -> char_p::Box
 {
     char_p::new("Hello, World!")
 }
@@ -192,7 +194,8 @@ fn takes_out_slice (v: &mut Option<c_slice::Box<u8>>)
 pub enum MyBool { True, False = 1 }
 
 #[ffi_export(node_js)]
-fn boolify (b: MyBool) -> bool
+fn boolify (b: MyBool)
+  -> bool
 {
     matches!(b, MyBool::True)
 }
@@ -202,7 +205,16 @@ fn boolify (b: MyBool) -> bool
 pub enum MyBool2 { True, False = 1 }
 
 #[ffi_export(node_js)]
-fn boolify2 (b: MyBool2) -> bool
+fn boolify2 (b: MyBool2)
+  -> bool
 {
     matches!(b, MyBool2::True)
+}
+
+#[ffi_export(node_js(async_worker))]
+fn long_running ()
+  -> i32
+{
+    ::std::thread::sleep(::std::time::Duration::from_millis(100));
+    42
 }

--- a/nodejs_tests/tests/main.js
+++ b/nodejs_tests/tests/main.js
@@ -150,4 +150,24 @@ assert.deepEqual(
     [true, false],
 );
 
+(async function() {
+    const start = performance.now();
+    const ffi_long_running = ffi.long_running();
+    const end = performance.now();
+    const duration = end - start;
+    assert(duration < 0.5); // Not more than 0.5 ms to perform the call.
+    assert.deepEqual(
+        await Promise.race(
+            [
+                ffi_long_running.then(() => "long_running"),
+                new Promise((resolve, reject) => {
+                    setTimeout(resolve, 10, "short_running");
+                }),
+            ]
+        ),
+        "short_running",
+    );
+    assert.deepEqual(await ffi_long_running, 42);
+})()
+
 console.log('Node.js FFI tests passed successfully ✅');

--- a/src/proc_macro/ffi_export.rs
+++ b/src/proc_macro/ffi_export.rs
@@ -53,25 +53,75 @@ fn ffi_export (attrs: TokenStream, input: TokenStream)
   -> TokenStream
 {
     use ::proc_macro::{*, TokenTree as TT};
+    let ref mut attr_tokens = attrs.into_iter().peekable();
     #[cfg(feature = "node-js")]
     let mut node_js = None;
-    match attrs.into_iter().next() {
-        | Some(TT::Ident(kw)) if kw.to_string() == "node_js" => {
-            #[cfg(feature = "node-js")] {
-                let input = input.clone();
-                let fun: ItemFn = parse_macro_input!(input);
-                node_js = Some(::proc_macro2::Literal::usize_unsuffixed(fun.sig.inputs.len()));
-            }
-        },
-        | Some(unexpected_tt) => {
-            return compile_error("Unexpected parameter", unexpected_tt.span());
-        },
-        | None => {},
+    loop {
+        match attr_tokens.next() {
+            | Some(TT::Ident(kw)) if kw.to_string() == "node_js" => {
+                let mut is_async_worker = false;
+                match attr_tokens.peek() {
+                    | Some(TT::Group(g)) if matches!(g.delimiter(), Delimiter::Parenthesis) => {
+                        let mut tts = g.stream().into_iter().peekable();
+                        loop {
+                            match tts.next() {
+                                | None => break,
+                                | Some(TT::Ident(id)) if id.to_string() == "async_worker" => {
+                                    is_async_worker = true;
+                                },
+                                | Some(extraneous_tt) => return compile_error(
+                                    "Unexpected parameter",
+                                    extraneous_tt.span(),
+                                ),
+                            }
+                            if matches!(
+                                tts.peek(),
+                                Some(TT::Punct(p)) if p.as_char() == ','
+                            )
+                            {
+                                let _ = tts.next();
+                            }
+                        }
+                        let _consume_group = attr_tokens.next();
+                    },
+                    | _ => {},
+                }
+                let _ = is_async_worker;
+                #[cfg(feature = "node-js")] {
+                    let input = input.clone();
+                    let fun: ItemFn = parse_macro_input!(input);
+                    let prev = node_js.replace((
+                        ::proc_macro2::Literal::usize_unsuffixed(fun.sig.inputs.len()),
+                        is_async_worker,
+                    ));
+                    if prev.is_some() {
+                        return compile_error(
+                            "Duplicate `nodejs` parameter",
+                            kw.span(),
+                        );
+                    }
+                }
+            },
+            | Some(unexpected_tt) => return compile_error(
+                "Unexpected parameter", unexpected_tt.span(),
+            ),
+            | None => break,
+        }
+        if matches!(attr_tokens.peek(), Some(TT::Punct(p)) if p.as_char() == ',') {
+            let _ = attr_tokens.next();
+        }
     }
     #[cfg(feature = "node-js")]
-    let input = if let Some(arg_count) = node_js {
+    let input = if let Some((arg_count, is_async_worker)) = node_js {
+        let is_async_worker = if is_async_worker {
+            Some(::quote::quote!(
+                "async_worker",
+            ))
+        } else {
+            None
+        };
         let mut ts = TokenStream::from(::quote::quote!(
-            @[node_js(#arg_count)]
+            @[node_js(#arg_count, #is_async_worker)]
         ));
         ts.extend(input);
         ts


### PR DESCRIPTION
to perform the (potentially long) FFI operation on a background
threadpool (the Worker thread pool from N-API's libuv), and
immediately return a `js::Promise` from the caller N-API thread.

___

Basically, with this change,

```diff
- #[ffi_export(nodejs)]
+ #[ffi_export(nodejs(async_worker))]
  fn foo () …
```

makes it so the FFI function exported to Node.js through N-API immediately returns before performing any FFI computation or I/O operation, returning a promise handle with which await the completion of the task, which has been enqueued on a Worker pool thread 🙂 

  - cc @hamchapman @konstantinbe 