### PR TITLE
[Node.js] Improve the API and design of the async worker

### DIFF
--- a/nodejs_tests/tests/main.js
+++ b/nodejs_tests/tests/main.js
@@ -155,7 +155,7 @@ assert.deepEqual(
     const ffi_long_running = ffi.long_running();
     const end = performance.now();
     const duration = end - start;
-    assert(duration < 0.5); // Not more than 0.5 ms to perform the call.
+    assert(duration < 2.0); // Not more than 2 ms to perform the call.
     assert.deepEqual(
         await Promise.race(
             [


### PR DESCRIPTION
  - The `#[ffi_export(nodejs(async_worker))]` sugar now wraps the raw `CType` variants in an `UnsafeAssertSend` wrapper (after having checked that the `ReprC` whence each originates is indeed `Send`), to avoid unnecessary `Send`-related compilation errors (cc @konstantinbe);

  - Created an API that is more flexible than `JsPromise::spawn_on_worker_thread(move || -> impl ReprNApi { … })?`:

    ```rust
    AsyncWorkerTask {
        on_worker: Some(move || -> R { … }),
        then_on_main_js: move |env: Env, r: R| -> impl ReprNApi { … },
    }.spawn(env)?
    ```