### PR TITLE
Fix header generation failing for negative discriminants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ path = "src/_lib.rs"
 [package]
 name = "safer-ffi"
 # Keep in sync with `[dependencies.proc_macro]` and `src/proc_macro/Cargo.toml`
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2018"
 
@@ -60,7 +60,7 @@ proc-macro-hack = { version = "0.5.15", optional = true }
 [dependencies.proc_macro]
 package = "safer_ffi-proc_macro"
 path = "src/proc_macro"
-version = "0.0.5"
+version = "0.0.6"
 
 [dependencies.uninit]
 optional = true

--- a/src/layout/macros.rs
+++ b/src/layout/macros.rs
@@ -933,7 +933,7 @@ macro_rules! ReprC {
 
     (@deny_C $otherwise:tt) => ();
 
-    (@first ($($fst:tt)*) $($ignored:tt)?) => ($($fst)*);
+    (@first ($($fst:tt)*) $($ignored:tt)*) => ($($fst)*);
 }
 
 #[cfg(feature = "headers")]

--- a/src/proc_macro/Cargo.toml
+++ b/src/proc_macro/Cargo.toml
@@ -5,7 +5,7 @@ proc-macro = true
 [package]
 name = "safer_ffi-proc_macro"
 # Keep in sync with `/Cargo.toml`
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
by making the `@first` ternary macro pattern more flexible.

Indeed, it required taking only one extra `:tt` at most, which can be achieved by parenthesizing stuff or being very sure about what ends up being a single `:tt`.
I used an `:expr` there when working on the header generation of enums, since a high-level metavar capture such as `:expr` only yields a single tt (`None`-grouping / "invisible parens").
But the usage of `::mini_paste` induces a re-tokenization which removes those invisible parens, hence making multi-token expressions such as `-1` fail.