### PR TITLE
Add struct name right after `typedef struct`

### DIFF
--- a/src/layout/macros.rs
+++ b/src/layout/macros.rs
@@ -137,7 +137,7 @@ macro_rules! CType {(
                         $crate::__output_docs__!(out, "", $($doc_meta)*);
                     )?
                     $crate::__output_docs__!(out, "", $(#[$($meta)*])*);
-                    $crate::core::writeln!(out, "typedef struct {}_t {{\n", me)?;
+                    $crate::core::writeln!(out, "typedef struct {} {{\n", me)?;
                     $(
                         if $crate::core::mem::size_of::<$field_ty>() > 0 {
                             // $crate::core::writeln!(out, "")?;

--- a/src/layout/macros.rs
+++ b/src/layout/macros.rs
@@ -137,7 +137,7 @@ macro_rules! CType {(
                         $crate::__output_docs__!(out, "", $($doc_meta)*);
                     )?
                     $crate::__output_docs__!(out, "", $(#[$($meta)*])*);
-                    $crate::core::writeln!(out, "typedef struct {{\n")?;
+                    $crate::core::writeln!(out, "typedef struct {}_t {{\n", me)?;
                     $(
                         if $crate::core::mem::size_of::<$field_ty>() > 0 {
                             // $crate::core::writeln!(out, "")?;


### PR DESCRIPTION
This is required to use header file in [Vlang](https://github.com/vlang/v).

(I don't know any downside for this change)
