### PR TITLE
Amend `executor` support to *require* the `fn` to be `async`

### DIFF
--- a/ffi_tests/src/lib.rs
+++ b/ffi_tests/src/lib.rs
@@ -145,8 +145,8 @@ fn generate_headers ()
     }
 })}
 
-#[ffi_export(async_executor = futures::executor::block_on)]
-fn async_get_ft ()
+#[ffi_export(executor = futures::executor::block_on)]
+async fn async_get_ft ()
   -> i32
 {
     ffi_await!(async { 42 })

--- a/js_tests/src/lib.rs
+++ b/js_tests/src/lib.rs
@@ -217,8 +217,8 @@ fn long_running ()
     42
 }
 
-#[ffi_export(node_js, async_executor = ::futures::executor::block_on)]
-fn long_running_fut (bytes: c_slice::Ref<'_, u8>)
+#[ffi_export(node_js, executor = ::futures::executor::block_on)]
+async fn long_running_fut (bytes: c_slice::Ref<'_, u8>)
   -> u8
 {
     let wait_time = 300;

--- a/src/proc_macro/ffi_export/_mod.rs
+++ b/src/proc_macro/ffi_export/_mod.rs
@@ -59,16 +59,12 @@ fn ffi_export (attrs: TokenStream, input: TokenStream)
         parse_macro_input!(input)
     };
     #[cfg(feature = "async-fn")] {
-        if let Some(asyncness) = fun.sig.asyncness {
-            return Error::new_spanned(asyncness, "\
-                `#[ffi_export(…)]` does not support `async fn`: \
-                add an `async_executor = …` parameter and then use \
-                `ffi_await!(…)` as the last expression of the function's body.\
-            ").into_compile_error().into();
-        }
         let attrs = attrs.clone();
         match parse::<async_fn::Attrs>(attrs) {
-            | Ok(attrs) if attrs.block_on.is_some() => {
+            | Ok(attrs)
+                if attrs.block_on.is_some()
+                || fun.sig.asyncness.is_some()
+            => {
                 return async_fn::export(attrs, &fun);
             },
             | _ => {},


### PR DESCRIPTION
This makes a few improvements _w.r.t._ the `ffi_await!` support to require, mainly, that the annotated function be an `async fn`, as suggested by @hamchapman 