### PR TITLE
[js] Make proper support for 64-bit ints through js `BigInt`s

### DIFF
--- a/js_tests/src/lib.rs
+++ b/js_tests/src/lib.rs
@@ -232,10 +232,30 @@ async fn long_running_fut (bytes: c_slice::Ref<'_, u8>)
 }
 
 #[ffi_export(node_js)]
-fn site_id (id: [u8;8])
+fn site_id (id: [u8; 8])
   -> char_p::Box
 {
     char_p::new(format!("{:02x?}", id))
+}
+
+#[ffi_export(node_js)]
+fn check_big_int_unsigned (
+    value: u64,
+    expected: char_p::Ref<'_>,
+) -> u64
+{
+    assert_eq!(value.to_string(), expected.to_str());
+    value
+}
+
+#[ffi_export(node_js)]
+fn check_big_int_signed (
+    value: i64,
+    expected: char_p::Ref<'_>,
+) -> i64
+{
+    assert_eq!(value.to_string(), expected.to_str());
+    value
 }
 
 // ---

--- a/js_tests/tests/tests.mjs
+++ b/js_tests/tests/tests.mjs
@@ -33,6 +33,76 @@ export async function run_tests({ ffi, performance, assert, is_web }) {
         });
     });
 
+    // Unsigned
+    for(const bigint of [
+        0, 0n,
+        1, 1n,
+        2 ** 53 - 2, 2n ** 53n - 2n,
+        2 ** 53 - 1, 2n ** 53n - 1n,
+        2n ** 53n - 0n,
+        2n ** 53n + 1n,
+        2n ** 53n + 2n,
+        2n ** 64n - 2n,
+        2n ** 64n - 1n,
+    ]) {
+        var bigint2;
+        assertCheckPointIsCalled((checkPoint) => {
+            // console.log(bigint.toString(), typeof bigint);
+            var errored;
+            ffi.withCString(bigint.toString(), (s) => {
+                try {
+                    checkPoint();
+                    bigint2 = ffi.check_big_int_unsigned(
+                        bigint,
+                        s,
+                    );
+                    assert(bigint == bigint2);
+                } catch(e) {
+                    errored = e;
+                }
+            });
+            if (errored) {
+                throw(errored);
+            }
+        });
+        assert(bigint == bigint2);
+    }
+    // Signed
+    for(const bigint of [
+        -(2n ** 63n),
+        -(2n ** 63n - 1n),
+        -(2n ** 53n + 1n),
+        -(2n ** 53n - 0n),
+        -(2n ** 53n - 1n), -(2 ** 53 - 1),
+        -1, -1n,
+        0, 0n,
+        1, 1n,
+        2n ** 53n - 1n, 2 ** 53 - 1,
+        2n ** 53n - 0n,
+        2n ** 53n + 1n,
+        2n ** 63n - 1n,
+    ]) {
+        var bigint2;
+        assertCheckPointIsCalled((checkPoint) => {
+            var errored;
+            ffi.withCString(bigint.toString(), (s) => {
+                try {
+                    checkPoint();
+                    bigint2 = ffi.check_big_int_signed(
+                        bigint,
+                        s,
+                    );
+                } catch(e) {
+                    errored = e;
+                }
+            });
+            if (errored) {
+                throw(errored);
+            }
+        });
+        assert(bigint == bigint2);
+    }
+
     assertCheckPointIsCalled((checkPoint) => {
         ffi.withCString("Hello, ", (s1) => {
             ffi.withCString("World!", (s2) => {

--- a/napi-dispatcher/Cargo.toml
+++ b/napi-dispatcher/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 napi.version = "1.1.3"
-napi.features = ["napi5", "tokio_rt"]
+napi.features = ["napi6", "tokio_rt"]
 # We need some napi enhancements featured in our fork, while waiting for those
 # to be merged upstream (we did get the `Result`-less `ThreadsafeFunction`
 # (c.f. 7108cc0f762d8cea3b2923b3bc529e4361557b30) to be merged but not released,

--- a/napi-dispatcher/wasm/src/lib.rs
+++ b/napi-dispatcher/wasm/src/lib.rs
@@ -70,6 +70,7 @@ struct Error {
 }
 
 utils::new_type_wrappers! {
+    pub type JsBigint = ::wasm_bindgen::JsValue; // ;__;
     pub type JsBoolean = ::js_sys::Boolean;
     pub type JsBuffer = ::js_sys::Uint8Array;
     pub type JsFunction = ::js_sys::Function;
@@ -101,7 +102,7 @@ enum Status {
 #[non_exhaustive]
 pub
 enum ValueType {
-    BigInt,
+    Bigint,
     Boolean,
     Function,
     Null,


### PR DESCRIPTION
While we had stuff such as `i64 : ReprNapi`, this property was actually a (runtime) lie: for values beyond the `±Number.MAX_SAFE_INTEGER` (`2 ** 53 - 1`) range, the Wasm side was silently yielding absurd value, and the Node.js / N-API side was throwing an error.

  - For Node.js, through N-API, proper support for the remaining range has been added through `BigInt`s;
  - For Wasm, since, it doesn't support `BigInt`s yet (it cannot interface with them), the out-of-range values cross the FFI boundary through a "stringified ABI", and support for the remaining range is this way achieved.