### PR TITLE
Node.js | Add support for detached callbacks

### DIFF
--- a/src/_lib.rs
+++ b/src/_lib.rs
@@ -8,7 +8,7 @@
     no_std,
 )]
 
-#![allow(nonstandard_style, trivial_bounds)]
+#![allow(nonstandard_style, trivial_bounds, unused_parens)]
 #![warn(
     missing_copy_implementations,
     missing_debug_implementations,

--- a/src/layout/_mod.rs
+++ b/src/layout/_mod.rs
@@ -81,7 +81,7 @@ unsafe trait CType
     Sized +
     Copy +
 {
-    type OPAQUE_KIND : OpaqueKind::__;
+    type OPAQUE_KIND : OpaqueKind::T;
     __cfg_headers__! {
         /// A short-name description of the type, mainly used to fill
         /// "placeholders" such as when monomorphising generics structs or


### PR DESCRIPTION
The `Closure<fn(…) -> …>` now supports a `Closure<fn(…), SyncKind::Detached>` form as well (note the mandatory `-> ()` return type) with which one ops out of the wait-for-completion-through-a-return-value-channel synchronicity of callback invocations, whereby they are always enqueued for a detached call (by the main js thread).

This is useful for unimportant, causality-wise, callbacks such as locks, since it reduces the risks of deadlocks.