### PR TITLE
Avoid wrapping `mod ffi_export` within an anonymous constant

### DIFF
--- a/src/_lib.rs
+++ b/src/_lib.rs
@@ -98,10 +98,8 @@ mod char_p;
 pub
 mod closure;
 
-const _: () = {
-    #[path = "ffi_export.rs"]
-    mod ffi_export;
-};
+#[path = "ffi_export.rs"]
+mod __ffi_export;
 
 pub
 mod ptr;

--- a/src/ffi_export.rs
+++ b/src/ffi_export.rs
@@ -31,7 +31,7 @@ macro_rules! __ffi_export__ {(
     )?
         $body
 
-    #[allow(dead_code, nonstandard_style, unused_parens)]
+    #[allow(dead_code, nonstandard_style, unused_parens, clippy::all)]
     const _: () = {
         $($(#[doc = $doc])+)?
         #[no_mangle]
@@ -116,7 +116,7 @@ macro_rules! __ffi_export__ {(
         $crate::inventory::submit! {
             #![crate = $crate]
             $crate::FfiExport({
-                #[allow(unused_parens)]
+                #[allow(unused_parens, clippy::all)]
                 fn typedef $(<$($lt $(: $sup_lt)?),*>)? (
                     definer: &'_ mut dyn $crate::headers::Definer,
                 ) -> $crate::std::io::Result<()>


### PR DESCRIPTION
May fix #79; @mattoni could you check to see if with

```toml
[patch.crates-io.safer-ffi]
version = "0.0.6"
git = "https://github.com/getditto/safer_ffi"
branch = "test_ffi_export_ide_improvement"
```

the diagnostics improve?