### PR TITLE
Docs whitespace tweak 

### DIFF
--- a/src/ffi_export.rs
+++ b/src/ffi_export.rs
@@ -271,7 +271,7 @@ macro_rules! __ffi_export__ {(
                         )?;
                         $(
                             $crate::core::write!(out,
-                                " * {}\n", $doc,
+                                " *{sep}{}\n", $doc, sep = if $doc.is_empty() { "" } else { " " },
                             )?;
                         )+
                         $crate::std::io::Write::write_all(out,


### PR DESCRIPTION
Tweak the writing out of documentation so that if there's a line that is empty then no leading space will be written out for that line in the generated file(s).
