### PR TITLE
Fix incorrect C header guard when the `PKG_NAME` contains hyphens

### DIFF
--- a/src/headers/_mod.rs
+++ b/src/headers/_mod.rs
@@ -269,7 +269,7 @@ with_optional_fields! {
     /// It defaults to:
     ///
     /// ```rust,ignore
-    /// format!("__RUST_{}__", env::var("CARGO_PKG_NAME")?.to_ascii_uppercase())
+    /// format!("__RUST_{}__", env::var("CARGO_PKG_NAME")?.replace("-", "_").to_ascii_uppercase())
     /// ```
     guard: &'__ str,
 
@@ -318,6 +318,7 @@ impl Builder<'_, WhereTo> {
                 s = format!("__RUST_{}__",
                     env::var("CARGO_PKG_NAME")
                         .unwrap()
+                        .replace("-", "_")
                         .to_ascii_uppercase()
                 );
                 &*s


### PR DESCRIPTION
Fixes #86: the default header guard just used `CARGO_PKG_NAME` which can contain hyphens, yielding a:

```c
#ifndef HYPHENATED-NAME
```

kind of code, which is not valid.

@Karrq can you check that:

```toml
# workspace's Cargo.toml

[patch.crates-io.safer-ffi]
git = "https://github.com/getditto/safer_ffi"
branch = "fix-incorrectly-hyphenated-header-guard"
```

  - (Plus `cargo update -p safer_ffi` to update to the latest state of the branch)

fixes the issue?