### PR TITLE
🔗 Fix link to blog post

### DIFF
--- a/guide/src/example-ditto/_.md
+++ b/guide/src/example-ditto/_.md
@@ -4,6 +4,6 @@
 
 <span style="text-align: center">
 
-### [![ditto-logo-no-title] **See our  blog post** ![ditto-logo-no-title]](https://www.ditto.live/blog/posts/introducing-safer-ffi)
+### [![ditto-logo-no-title] **See our  blog post** ![ditto-logo-no-title]](https://www.ditto.live/blog/introducing-safer-ffi)
 
 </span>


### PR DESCRIPTION
Just noticed the URL to our "Introducing Safer FFI" blog post has changed slightly.