### PR TITLE
96 export enum constant which are not used by a function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ fn mid_point(a: &Point, b: &Point) -> Point {
     }
 }
 
+/* Export a Rust enum to C */
+#[ffi_export]
+#[derive_ReprC]
+#[repr(u8)]
+pub enum Figure {
+	Circle,
+	Square
+}
+
 /// Pretty-prints a point using Rust's formatting logic.
 #[ffi_export]
 fn print_point(point: &Point) {
@@ -140,6 +149,13 @@ typedef struct {
 Point_t mid_point (
     Point_t const * a,
     Point_t const * b);
+
+typedef enum Figure 
+{
+	FIGURE_CIRCLE,
+	FIGURE_SQUARE
+} Figure_t;
+
 
 /** \brief
  *  Pretty-prints a point using Rust's formatting logic.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ fn mid_point(a: &Point, b: &Point) -> Point {
 }
 
 /* Export a Rust enum to C */
-#[ffi_export]
+#[ffi_export] // directly exporting a type is only needed
+              // if no exported function mentions it
 #[derive_ReprC]
 #[repr(u8)]
 pub enum Figure {

--- a/ffi_tests/generated.h
+++ b/ffi_tests/generated.h
@@ -14,19 +14,27 @@
 extern "C" {
 #endif
 
-typedef struct foo foo_t;
-
-foo_t * new_foo (void);
-
 
 #include <stddef.h>
 #include <stdint.h>
 
-int32_t read_foo (
-    foo_t const * foo);
+/** \remark Has the same ABI as `uint8_t` **/
+#ifdef DOXYGEN
+typedef enum Bar
+#else
+typedef uint8_t Bar_t; enum
+#endif
+{
+    /** . */
+    BAR_A,
+}
+#ifdef DOXYGEN
+Bar_t
+#endif
+;
 
-void free_foo (
-    foo_t * foo);
+void check_bar (
+    Bar_t _bar);
 
 /** \brief
  *  Concatenate the two input strings into a new one.
@@ -43,7 +51,7 @@ char * concat (
 void free_char_p (
     char * _string);
 
-typedef struct {
+typedef struct RefDynFnMut1_void_char_const_ptr {
 
     void * env_ptr;
 
@@ -79,16 +87,10 @@ void with_concat (
  *  allowed to be `NULL` (with the contents of `len` then being undefined)
  *  use the `Option< slice_ptr<_> >` type.
  */
-typedef struct {
+typedef struct slice_ref_int32 {
 
-    /** \brief
-     *  Pointer to the first element (if any).
-     */
     int32_t const * ptr;
 
-    /** \brief
-     *  Element count
-     */
     size_t len;
 
 } slice_ref_int32_t;
@@ -102,21 +104,49 @@ int32_t const * max (
 
 /** \remark Has the same ABI as `uint8_t` **/
 #ifdef DOXYGEN
-typedef enum Bar
+typedef enum Wow
 #else
-typedef uint8_t Bar_t; enum
+typedef uint8_t Wow_t; enum
 #endif
 {
     /** . */
-    BAR_A,
+    WOW_LEROY,
+    /** . */
+    WOW_JENKINS,
 }
 #ifdef DOXYGEN
-Bar_t
+Wow_t
 #endif
 ;
 
-void check_bar (
-    Bar_t _bar);
+/** \remark Has the same ABI as `uint8_t` **/
+#ifdef DOXYGEN
+typedef enum Triforce
+#else
+typedef uint8_t Triforce_t; enum
+#endif
+{
+    /** . */
+    TRIFORCE_DIN = 3,
+    /** . */
+    TRIFORCE_FARORE = 1,
+    /** . */
+    TRIFORCE_NARYU,
+}
+#ifdef DOXYGEN
+Triforce_t
+#endif
+;
+
+typedef struct foo foo_t;
+
+foo_t * new_foo (void);
+
+int32_t read_foo (
+    foo_t const * foo);
+
+void free_foo (
+    foo_t * foo);
 
 
 #ifdef __cplusplus

--- a/ffi_tests/src/lib.rs
+++ b/ffi_tests/src/lib.rs
@@ -84,6 +84,23 @@ mod bar {
     {}
 }
 
+#[ffi_export]
+#[derive_ReprC]
+#[repr(u8)]
+pub enum Wow {
+    Leroy,
+    Jenkins,
+}
+
+#[ffi_export]
+#[derive_ReprC]
+#[repr(u8)]
+pub enum Triforce {
+    Din = 3,
+    Farore = 1,
+    Naryu,
+}
+
 #[safer_ffi::cfg_headers]
 #[test]
 fn generate_headers ()

--- a/src/proc_macro/ffi_export.rs
+++ b/src/proc_macro/ffi_export.rs
@@ -56,10 +56,6 @@ fn ffi_export (attrs: TokenStream, input: TokenStream)
     if let Some(unexpected_tt) = attrs.into_iter().next() {
         return compile_error("Unexpected parameter", unexpected_tt.span());
     }
-    #[cfg(feature = "proc_macros")] {
-        let input = input.clone();
-        let _: ItemFn = parse_macro_input!(input);
-    }
     let span = Span::call_site();
     <TokenStream as ::std::iter::FromIterator<_>>::from_iter(vec![
         TT::Punct(Punct::new(':', Spacing::Joint)),


### PR DESCRIPTION
ffi_export can now be applied to enums.

Furthermore Readme.md has been updated accordingly.