### PR TITLE
Add `inventory-0-3-1` optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,11 @@ js = [
     "std",
 ]
 
+inventory-0-3-1 = [
+    "dep:inventory-0-3-1",
+    "safer_ffi-proc_macros/inventory-0-3-1",
+]
+
 [dev-dependencies]
 macro_rules_attribute = "0.1.0"
 safer-ffi.path = "."
@@ -94,6 +99,12 @@ scopeguard.version = "1.1.0"
 unwind_safe.version = "0.1.0"
 with_builtin_macros.version = "0.0.3"
 macro_rules_attribute = "0.1.0"
+
+
+[dependencies.inventory-0-3-1]
+package = "inventory"
+version = "0.3.1"
+optional = true
 
 [dependencies.napi]
 package = "napi-dispatcher"

--- a/napi-dispatcher/nodejs-derive/src/proc_macros/mod.rs
+++ b/napi-dispatcher/nodejs-derive/src/proc_macros/mod.rs
@@ -92,6 +92,9 @@ fn js_export (
         )
     };
     let stmts = &fun.block.stmts;
+    let krate_annotation = cfg!(not(feature = "inventory-0-3-1")).then(|| {
+        quote!( #![crate = ::safer_ffi::js::registering] )
+    });
     let ret = quote!(
         const _: () = {
             #napi_import
@@ -106,7 +109,7 @@ fn js_export (
             }
 
             ::safer_ffi::js::registering::submit! {
-                #![crate = ::safer_ffi::js::registering]
+                #krate_annotation
 
                 ::safer_ffi::js::registering::NapiRegistryEntry::NamedMethod {
                     name: ::core::stringify!(#js_name),

--- a/src/_lib.rs
+++ b/src/_lib.rs
@@ -223,8 +223,16 @@ pub use ::safer_ffi_proc_macros::derive_ReprC;
 pub mod layout;
 
 __cfg_headers__! {
-    #[doc(hidden)] pub
-    use ::inventory;
+    cfg_match! {
+        feature = "inventory-0-3-1" => {
+            #[doc(hidden)] pub
+            use ::inventory_0_3_1 as inventory;
+        },
+        _ => {
+            #[doc(hidden)] pub
+            use ::inventory;
+        },
+    }
 
     #[cfg_attr(feature = "nightly",
         doc(cfg(feature = "headers")),
@@ -246,7 +254,7 @@ __cfg_headers__! {
         ,
     }
 
-    ::inventory::collect!(FfiExport);
+    self::inventory::collect!(FfiExport);
 }
 
 cfg_alloc! {
@@ -481,7 +489,6 @@ mod __ {
 
     #[cfg(feature = "headers")]
     pub use {
-        ::inventory,
         crate::{
             headers::{
                 Definer,
@@ -494,6 +501,7 @@ mod __ {
                     StructField,
                 },
             },
+            inventory,
             FfiExport,
         },
     };

--- a/src/js/registering.rs
+++ b/src/js/registering.rs
@@ -26,9 +26,9 @@ enum NapiRegistryEntry {
     },
 }
 
-::inventory::collect!(NapiRegistryEntry);
+self::inventory::collect!(NapiRegistryEntry);
 
-pub use ::inventory::{self, submit};
+pub use crate::inventory::{self, submit};
 
 #[cold]
 pub
@@ -41,7 +41,7 @@ fn napi_register_module_v1 (
     // let env = ::napi::Env::from_raw(raw_env);
     let mut exports: ::napi::JsObject = ::napi::NapiValue::from_raw_unchecked(raw_env, raw_exports);
     match (|| ::napi::Result::<_>::Ok({
-        for entry in ::inventory::iter::<NapiRegistryEntry> {
+        for entry in crate::inventory::iter::<NapiRegistryEntry> {
             match entry {
                 | &NapiRegistryEntry::NamedMethod { name, method } => {
                     let _ = exports.create_named_method(name, method);

--- a/src/proc_macro/Cargo.toml
+++ b/src/proc_macro/Cargo.toml
@@ -37,3 +37,5 @@ js = [
 verbose-expansions = [
     # "prettyplease",
 ]
+
+inventory-0-3-1 = []

--- a/src/proc_macro/ffi_export/const_.rs
+++ b/src/proc_macro/ffi_export/const_.rs
@@ -24,12 +24,16 @@ fn handle (
         let Ty @ _ = &input.ty;
         let ref each_doc = utils::extract_docs(&input.attrs)?;
 
+        let inventory_krate = cfg!(not(feature = "inventory-0-3-1")).then(|| {
+            quote!( #![crate = #ඞ] )
+        });
         Ok(quote!(
             #input
 
             #[cfg(not(target_arch = "wasm32"))]
             #ඞ::inventory::submit! {
-                #![crate = #ඞ]
+                #inventory_krate
+
                 #ඞ::FfiExport {
                     name: #VAR_str,
                     gen_def: |

--- a/src/proc_macro/ffi_export/fn_/mod.rs
+++ b/src/proc_macro/ffi_export/fn_/mod.rs
@@ -358,10 +358,14 @@ fn handle (
         let ref EachArgTy @ _ = arg_tys(&fun).vec();
         let each_doc = utils::extract_docs(&fun.attrs)?;
         let (generics, _, where_clause) = fun.sig.generics.split_for_impl();
+        let inventory_krate = cfg!(not(feature = "inventory-0-3-1")).then(|| {
+            quote!( #![crate = #ඞ] )
+        });
         ret.extend(quote!(
             #[cfg(not(target_arch = "wasm32"))]
             #ඞ::inventory::submit! {
-                #![crate = #ඞ]
+                #inventory_krate
+
                 #ඞ::FfiExport {
                     name: #export_name_str,
                     gen_def: {

--- a/src/proc_macro/ffi_export/type_.rs
+++ b/src/proc_macro/ffi_export/type_.rs
@@ -19,13 +19,16 @@ fn handle (
         }
     }
     let ref Ty_str @ _ = Ty.to_string();
+    let inventory_krate = cfg!(not(feature = "inventory-0-3-1")).then(|| {
+        quote!( #![crate = ::safer_ffi] )
+    });
     Ok(quote!(
         #input
 
         #[cfg(not(target_arch = "wasm32"))]
         ::safer_ffi::__cfg_headers__! {
             ::safer_ffi::inventory::submit! {
-                #![crate = ::safer_ffi]
+                #inventory_krate
 
                 ::safer_ffi::FfiExport {
                     name: #Ty_str,


### PR DESCRIPTION
 1. In more recent rust toolchains and/or specific platforms, the `ctor` hack which `inventory` relied on was broken (causing #131);
 1. Since Rust 1.62.0, `inventory 0.3.*` has been released which, would solve the issue.
 1. But the MSRV of `safer-ffi` is 1.60.0.

Thence the idea to rely on a Cargo feature for 1.62.0+ users to replace `inventory` with `inventory 0.3.1`. This, thus, could have been expected to fix the issue #131 (EDIT: it doesn't 😔).

  - @pan93412 can you try this and confirm that it fixes the issue?

    ```toml
    [patch.crates-io.safer-ffi]
    git = "https://github.com/getditto/safer_ffi.git"
    branch = "inventory-bump"
    ```

    And then, at https://github.com/pan93412/libstock-ffi/blob/e87b04cf6e1bd9394db656315f1dbd2975418c95/Cargo.toml#L27, you should add `inventory-0-3-1` as well:

    ```diff
    - headers = ["safer-ffi/headers"]
    + headers = ["safer-ffi/headers", "safer-ffi/inventory-0-3-1"]
    ```