### PR TITLE
Nicer closure aliases: `repr_c::Box<dyn FnMut…>`, `repr_c::Arc<dyn Fn…>`

### DIFF
--- a/ffi_tests/generated.cs
+++ b/ffi_tests/generated.cs
@@ -89,6 +89,35 @@ public unsafe partial class Ffi {
     Int32 async_get_ft ();
 }
 
+[UnmanagedFunctionPointer(CallingConvention.Winapi)]
+public unsafe /* static */ delegate
+    void
+    void_void_ptr_fptr (
+        void * _0);
+
+/// <summary>
+/// <c>Arc<dyn Send + Sync + Fn() -> Ret></c>
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Size = 32)]
+public unsafe struct ArcDynFn0_void_t {
+    public void * env_ptr;
+
+    [MarshalAs(UnmanagedType.FunctionPtr)]
+    public void_void_ptr_fptr call;
+
+    [MarshalAs(UnmanagedType.FunctionPtr)]
+    public void_void_ptr_fptr release;
+
+    [MarshalAs(UnmanagedType.FunctionPtr)]
+    public void_void_ptr_fptr retain;
+}
+
+public unsafe partial class Ffi {
+    [DllImport(RustLib, ExactSpelling = true)] public static unsafe extern
+    void call_in_the_background (
+        ArcDynFn0_void_t f);
+}
+
 /// <summary>
 /// This is a <c>#[repr(C)]</c> enum, which leads to a classic enum def.
 /// </summary>

--- a/ffi_tests/generated.h
+++ b/ffi_tests/generated.h
@@ -108,6 +108,28 @@ int32_t
 async_get_ft (void);
 
 /** \brief
+ *  `Arc<dyn Send + Sync + Fn() -> Ret>`
+ */
+typedef struct ArcDynFn0_void {
+    /** <No documentation available> */
+    void * env_ptr;
+
+    /** <No documentation available> */
+    void (*call)(void *);
+
+    /** <No documentation available> */
+    void (*release)(void *);
+
+    /** <No documentation available> */
+    void (*retain)(void *);
+} ArcDynFn0_void_t;
+
+/** <No documentation available> */
+void
+call_in_the_background (
+    ArcDynFn0_void_t f);
+
+/** \brief
  *  This is a `#[repr(C)]` enum, which leads to a classic enum def.
  */
 typedef enum SomeReprCEnum {

--- a/ffi_tests/src/lib.rs
+++ b/ffi_tests/src/lib.rs
@@ -36,6 +36,18 @@ fn returns_a_fn_ptr ()
     f
 }
 
+#[ffi_export]
+fn call_in_the_background (
+    f: repr_c::Arc<dyn Send + Sync + Fn()>,
+)
+{
+    let f2 = f.clone();
+    ::std::thread::spawn(move || {
+        f2.call()
+    });
+    drop(f);
+}
+
 /// https://github.com/getditto/safer_ffi/issues/45
 #[ffi_export]
 fn _issue_45<'a, 'b> (_: i32)
@@ -92,7 +104,8 @@ mod foo {
     #[ffi_export]
     fn new_foo () -> repr_c::Box<Foo>
     {
-        repr_c::Box::new(Foo { hidden: 42 })
+        Box::new(Foo { hidden: 42 })
+            .into()
     }
 
     #[ffi_export]

--- a/src/_lib.rs
+++ b/src/_lib.rs
@@ -348,6 +348,9 @@ mod prelude {
                 string::String,
                 vec::Vec,
             };
+
+            pub
+            type Arc<T> = <T as crate::boxed::FitForCArc>::CArcWrapped;
         }
     }
     pub

--- a/src/closure/borrowed.rs
+++ b/src/closure/borrowed.rs
@@ -48,6 +48,25 @@ macro_rules! with_tuple {(
         $A_k : ReprC, )*)?
     {}
 
+    impl<'lt, F, Ret $(, $A_N $(, $A_k)*)?>
+        From<&'lt mut F>
+    for
+        $RefDynFnMut_N<'lt, Ret $(, $A_N $(, $A_k)*)?>
+    where
+        Ret : ReprC, $(
+        $A_N : ReprC, $(
+        $A_k : ReprC, )*)?
+        F : Fn( $($A_N $(, $A_k)*)? ) -> Ret,
+        F : Send + 'static,
+    {
+        #[inline]
+        fn from (f: &'lt mut F)
+          -> Self
+        {
+            Self::new(f)
+        }
+    }
+
     impl<'lt, Ret $(, $A_N $(, $A_k)*)?>
         $RefDynFnMut_N <'lt, Ret $(, $A_N $(, $A_k)*)?>
     where

--- a/src/closure/boxed.rs
+++ b/src/closure/boxed.rs
@@ -10,6 +10,18 @@ macro_rules! with_tuple {(
         $( $A_N:ident, $($A_k:ident ,)* )?
     )
 ) => (
+    impl<Ret $(, $A_N $(, $A_k)*)?>
+        crate::boxed::FitForCBox
+    for
+        dyn 'static + Send + FnMut($($A_N $(, $A_k)*)?) -> Ret
+    where
+        Ret : ReprC, $(
+        $A_N : ReprC, $(
+        $A_k : ReprC, )*)?
+    {
+        type CBoxWrapped = $BoxDynFnMut_N<Ret $(, $A_N $(, $A_k)*)?>;
+    }
+
     ReprC! {
         @[doc = concat!(
             "`Box<dyn 'static + Send + FnMut(" $(,
@@ -52,6 +64,25 @@ macro_rules! with_tuple {(
             $A_N : ReprC, $(
             $A_k : ReprC, )*)?
         {}
+
+    impl<F, Ret $(, $A_N $(, $A_k)*)?>
+        From<rust::Box<F>>
+    for
+        $BoxDynFnMut_N <Ret $(, $A_N $(, $A_k)*)?>
+    where
+        Ret : ReprC, $(
+        $A_N : ReprC, $(
+        $A_k : ReprC, )*)?
+        F : FnMut( $($A_N $(, $A_k)*)? ) -> Ret,
+        F : Send + 'static,
+    {
+        #[inline]
+        fn from (f: rust::Box<F>)
+          -> Self
+        {
+            Self::new(f)
+        }
+    }
 
     impl<Ret $(, $A_N $(, $A_k)*)?>
         $BoxDynFnMut_N <Ret $(, $A_N $(, $A_k)*)?>

--- a/src/closure/mod.rs
+++ b/src/closure/mod.rs
@@ -4,6 +4,53 @@
 //!
 //! Simplified for lighter documentation, but the actual `struct` definitions
 //! and impls range up to `...DynFn...9`.
+//!
+//! ## Examples
+//!
+//! ### FFI-safe `Box<dyn FnMut()>`
+//!
+/*!  - ```rust
+    use ::safer_ffi::prelude::*;
+
+    let mut captured = String::from("…");
+    let ffi_safe: repr_c::Box<dyn Send + FnMut()> =
+        Box::new(move || {
+            captured.push('!');
+            println!("{}", captured);
+        })
+        .into()
+    ;
+
+    fn assert_ffi_safe (_: &impl ReprC)
+    {}
+    assert_ffi_safe(&ffi_safe);
+    ``` */
+//!
+//! ### FFI-safe `Arc<dyn Fn()>`
+//!
+/*!  - ```rust
+    use ::{
+        safer_ffi::{
+            prelude::*,
+        },
+        std::{
+            sync::Arc,
+        },
+    };
+
+    let captured = String::from("…");
+    let ffi_safe: repr_c::Arc<dyn Send + Sync + Fn()> =
+        Arc::new(move || {
+            println!("{}", captured);
+        })
+        .into()
+    ;
+
+    fn assert_ffi_safe (_: &impl ReprC)
+    {}
+    assert_ffi_safe(&ffi_safe);
+    ``` */
+//!
 
 cfg_alloc! {
     pub mod arc;
@@ -26,6 +73,7 @@ cfg_alloc! {
         },
     };
 }
+
 pub mod borrowed;
 
 #[doc(no_inline)]


### PR DESCRIPTION
### `repr_c::Arc`

is a new type under `repr_c::`, called `Arc`, which allows being fed a:

```rs
dyn 'static + Send + Sync + Fn(Args…) -> Ret
```

parameter, in order to refer to the `ArcDynFnN<Ret, Args…>` type.

Said type now implements `From<Arc<impl Fn…>>`.

### `repr_c::Box`

has been **replaced** with a similar alias, which now stands for the old `repr_c::Box` when the type parameter is `Sized`, and fox `BoxDynFnMut…` when it is `dyn … + FnMut…`.

The latter `BoxDynFnMut…` now also implements `From<Box<impl Fn…>>`.

The old `repr_c::Box` is now still available under `::safer_ffi::boxed::Box_`.

**This part is a breaking change since `repr_c::Box::new()` now yields type inference errors**.

This is deemed acceptable as this kind of change is part of a series of changes that are part of:

  - https://github.com/getditto/safer_ffi/issues/48

<img width="1192" alt="Screenshot 2022-08-24 at 16 09 54" src="https://user-images.githubusercontent.com/9920355/186440522-4bafb725-990e-47f8-9ec4-d001e28087db.png">