### PR TITLE
Implement `From` instead of `Into` for conversions to standard types

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -181,14 +181,13 @@ cfg_alloc! {
         }
     }
 
-    impl<T> Into<rust::Box<[T]>>
-        for slice_boxed<T>
+    impl<T> From<slice_boxed<T>> for rust::Box<[T]>
     {
         #[inline]
-        fn into (self: slice_boxed<T>)
+        fn from (value: slice_boxed<T>)
           -> rust::Box<[T]>
         {
-            let mut this = mem::ManuallyDrop::new(self);
+            let mut this = mem::ManuallyDrop::new(value);
             unsafe {
                 rust::Box::from_raw(
                     slice::from_raw_parts_mut(

--- a/src/string/_mod.rs
+++ b/src/string/_mod.rs
@@ -20,6 +20,7 @@ cfg_alloc! {
         );
     }
 
+    /// Convert a [`std::string::String`] to a [`safer_ffi::String`].
     impl From<rust::String>
         for String
     {
@@ -29,15 +30,16 @@ cfg_alloc! {
             Self(rust::Vec::from(s).into())
         }
     }
-    impl Into<rust::String>
-        for String
+
+    /// Convert a [`safer_ffi::String`] to a [`std::string::String`].
+    impl From<String> for rust::String
     {
         #[inline]
-        fn into (self: String) -> rust::String
+        fn from(value: String) -> rust::String
         {
             unsafe {
                 rust::String::from_utf8_unchecked(
-                    self.0.into()
+                    value.0.into()
                 )
             }
         }

--- a/src/string/slice.rs
+++ b/src/string/slice.rs
@@ -93,27 +93,25 @@ cfg_alloc! {
         }
     }
 
-    impl Into<rust::Box<str>>
-        for str_boxed
+    impl From<str_boxed> for rust::Box<str>
     {
-        fn into (self: str_boxed)
+        fn from (value: str_boxed)
           -> rust::Box<str>
         {
             unsafe {
                 rust::Box::from_raw(rust::Box::<[u8]>::into_raw(
-                    self.0.into()
+                    value.0.into()
                 ) as _)
             }
         }
     }
 
-    impl Into<rust::String>
-        for str_boxed
+    impl From<str_boxed> for rust::String
     {
-        fn into (self: str_boxed)
+        fn from (value: str_boxed)
           -> rust::String
         {
-            <rust::Box<str>>::into(self.into())
+            <rust::Box<str>>::into(value.into())
         }
     }
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -45,6 +45,7 @@ impl<T> Vec<T> {
     }
 }
 
+/// Convert a [`std::vec::Vec`] to a [`safer_ffi::Vec`].
 impl<T> From<rust::Vec<T>>
     for Vec<T>
 {
@@ -66,14 +67,14 @@ impl<T> From<rust::Vec<T>>
     }
 }
 
-impl<T> Into<rust::Vec<T>>
-    for Vec<T>
+/// Convert a [`safer_ffi::Vec`] to a [`std::vec::Vec`].
+impl<T> From<Vec<T>> for rust::Vec<T>
 {
     #[inline]
-    fn into (self: Vec<T>)
+    fn from (value: Vec<T>)
       -> rust::Vec<T>
     {
-        let mut this = mem::ManuallyDrop::new(self);
+        let mut this = mem::ManuallyDrop::new(value);
         unsafe {
             // Safety: pointers originate from `Vec`.
             rust::Vec::from_raw_parts(


### PR DESCRIPTION
Implementing `From` makes the API more flexible. For example, it allows patterns like `String::from(safer_ffi_string).into()`. The alternative `.into().into()` would not work because of missing type information.
 
Also, implementing `From` instead of `Into` is the official recommendation. As noted [in the standard library API docs](https://doc.rust-lang.org/stable/std/convert/trait.Into.html):

> One should avoid implementing [`Into`](https://doc.rust-lang.org/stable/std/convert/trait.Into.html) and implement [`From`](https://doc.rust-lang.org/stable/std/convert/trait.From.html) instead. Implementing [`From`](https://doc.rust-lang.org/stable/std/convert/trait.From.html) automatically provides one with an implementation of [`Into`](https://doc.rust-lang.org/stable/std/convert/trait.Into.html) thanks to the blanket implementation in the standard library.
