### PR TITLE
Fix version replacement instructions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ safer-ffi.features = [] # you may add some later on.
 headers = ["safer-ffi/headers"]
 ```
 
-  - Where `"*"` ought to be replaced by the last released version, which you
+  - Where `"x.y.z"` ought to be replaced by the last released version, which you
     can find by running `cargo search safer-ffi`.
 
   - See the [dedicated chapter on `Cargo.toml`][cargo-toml] for more info.

--- a/guide/src/introduction/quickstart.md
+++ b/guide/src/introduction/quickstart.md
@@ -45,7 +45,7 @@ safer-ffi.features = [] # you may add some later on.
 headers = ["safer-ffi/headers"]
 ```
 
-  - Where `"*"` ought to be replaced by the last released version, which you
+  - Where `"x.y.z"` ought to be replaced by the last released version, which you
     can find by running `cargo search safer-ffi`.
 
   - See the [dedicated chapter on `Cargo.toml`][cargo-toml] for more info.


### PR DESCRIPTION
Hi there, this PR fixes a tiny issue in the quickstart instructions. The quickstart uses `"x.y.z"` as a placeholder for the latest version, but the instructions say to replace `"*"`. It looks like the example `Cargo.toml` just got out of sync with the instructions.

Thanks for making `safer_ffi`!