### PR TITLE
Remove extern crates from napi-dispatcher

### DIFF
--- a/napi-dispatcher/dispatcher.rs
+++ b/napi-dispatcher/dispatcher.rs
@@ -11,12 +11,10 @@ macro_rules! emit {( $($_:tt)* ) => ( $($_)* )}
 }
 
 #[cfg(not(target_arch = "wasm32"))] emit! {
-    extern crate napi;
     pub use ::{
         napi::*,
+        napi_derive as derive,
     };
-
-    pub extern crate napi_derive as derive;
 
     pub type Result<T, E = Error> = ::core::result::Result<T, E>;
 }


### PR DESCRIPTION
Denying `rust_2018_idioms` flags the `extern crate napi;` as unused - and if I'm understanding Rust 2018 correctly, both of these can be removed because the `pub extern crate` can be turned into a re-export.

Am I off-base here? I don't think this should break anything.