### PR TITLE
Apply fix for thread-local error messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ c-headers-with-fn-style = [
 # PRIVATE FEATURE / not part of crates.io package!
 js = [
     "async-fn",
+    "dep:tokio",
     "headers",
     "inventory",
     "napi",

--- a/js_tests/Cargo.lock
+++ b/js_tests/Cargo.lock
@@ -566,6 +566,7 @@ dependencies = [
  "paste",
  "safer_ffi-proc_macros",
  "scopeguard",
+ "tokio",
  "uninit",
  "unwind_safe",
  "with_builtin_macros",


### PR DESCRIPTION
Copied over from https://github.com/getditto/ditto/pull/8123

In cargo.toml, tokio.version = "1.26.0" has been set in the meantime and as that is a newer version I didn't bring over the pin to tokio.version = "1.24.0".