### PR TITLE
`libc` improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-compat",
  "cratesio-placeholder-package",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,9 @@ inventory-0-3-1.optional = true
 inventory-0-3-1.package = "inventory"
 inventory-0-3-1.version = "0.3.1"
 
+libc.version = "0.2.66"
+libc.default-features = false
+
 log.optional = true
 log.version = "0.4.8"
 
@@ -162,10 +165,6 @@ version = "0.0.3"
 [dependencies.safer_ffi-proc_macros]
 path = "src/proc_macro"
 version = "=0.1.1"  # Keep in sync
-
-[target.'cfg(not(target = "wasm32-unknown-unknown"))'.dependencies]
-libc.version = "0.2.66"
-libc.default-features = false
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ path = "src/_lib.rs"
 
 [package]
 name = "safer-ffi"
-version = "0.1.1"  # Keep in sync
+version = "0.1.2"  # Keep in sync
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
@@ -164,7 +164,7 @@ version = "0.0.3"
 
 [dependencies.safer_ffi-proc_macros]
 path = "src/proc_macro"
-version = "=0.1.1"  # Keep in sync
+version = "=0.1.2"  # Keep in sync
 
 [workspace]
 members = [

--- a/ffi_tests/Cargo.lock
+++ b/ffi_tests/Cargo.lock
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "futures",
  "inventory",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/js_tests/Cargo.lock
+++ b/js_tests/Cargo.lock
@@ -557,7 +557,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cratesio-placeholder-package",
  "inventory",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/src/_lib.rs
+++ b/src/_lib.rs
@@ -269,6 +269,7 @@ cfg_alloc! {
     mod boxed;
 }
 
+#[doc(inline)]
 pub use self::c_char_module::c_char;
 #[path = "c_char.rs"]
 mod c_char_module;
@@ -293,6 +294,9 @@ mod dyn_traits;
 )]
 #[doc(no_inline)]
 pub use dyn_traits::futures;
+
+pub
+mod libc;
 
 pub
 mod ptr;
@@ -320,8 +324,8 @@ cfg_alloc! {
     pub mod vec;
 }
 
-#[apply(hidden_export)]
-use layout::impls::c_int;
+#[doc(inline)]
+pub use layout::impls::c_int;
 
 pub
 mod prelude {
@@ -445,16 +449,6 @@ macro_rules! __abort_with_msg__ { ($($tt:tt)*) => (
         $crate::ඞ::panic!($($tt)*);
     }}
 )}
-
-#[cfg(target_arch = "wasm32")]
-#[allow(dead_code)]
-mod libc {
-    pub type c_int = i32;
-    pub type size_t = u32;
-    pub type uintptr_t = u32;
-}
-#[cfg(not(target_arch = "wasm32"))]
-use ::libc;
 
 extern crate self as safer_ffi;
 

--- a/src/c_char.rs
+++ b/src/c_char.rs
@@ -1,6 +1,14 @@
 #![cfg_attr(rustfmt, rustfmt::skip)]
 use_prelude!();
 
+/// A `ReprC` _standalone_ type with the same layout and ABI as
+/// [`::libc::c_char`][crate::libc::c_char].
+///
+/// By _standalone_, the idea is that this is defined as a (`transparent`) _newtype_ `struct`,
+/// rather than as a _`type` alias_, which is error-prone and yields less-portable headers (since
+/// the header generation will resolve the type alias and emit, for instance, `int8_t`, ⚠️).
+///
+/// By using this type, you guarantee that the C `char` type be used in the headers.
 #[repr(transparent)]
 #[derive(
     Debug,
@@ -16,8 +24,7 @@ struct c_char /* = */ (
     u8,
 );
 
-/// Assert that `::libc::c_char` is either `uint8_t` or `int8_t`.
-#[cfg(not(any(target_arch = "wasm32", not(feature = "std"))))] // no libc on WASM nor no_std
+/// Assert that `crate::libc::c_char` is either `uint8_t` or `int8_t`.
 const _: () = {
     trait IsU8OrI8
     {}
@@ -33,7 +40,7 @@ const _: () = {
         fn is_u8_or_i8<T>() where
             T : IsU8OrI8,
         {}
-        let _ = is_u8_or_i8::<::libc::c_char>;
+        let _ = is_u8_or_i8::<crate::libc::c_char>;
     };
 };
 

--- a/src/layout/impls.rs
+++ b/src/layout/impls.rs
@@ -913,6 +913,14 @@ unsafe
     }
 from_CType_impl_ReprC! { Bool }
 
+/// A `ReprC` _standalone_ type with the same layout and ABI as
+/// [`::libc::c_int`][crate::libc::c_int].
+///
+/// By _standalone_, the idea is that this is defined as a (`transparent`) _newtype_ `struct`,
+/// rather than as a _`type` alias_, which is error-prone and yields less-portable headers (since
+/// the header generation will resolve the type alias and emit, for instance, `int32_t`, ⚠️).
+///
+/// By using this type, you guarantee that the C `int` type be used in the headers.
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub

--- a/src/libc.rs
+++ b/src/libc.rs
@@ -1,0 +1,73 @@
+#![cfg_attr(rustfmt, rustfmt::skip)]
+//! On certain platforms, `::libc` has no definitions for pervasive types such as `size_t`.
+//!
+//! We polyfill them here, and reëxport them for downstream users to use at leisure
+//! (_e.g._, so that they don't have to do that themselves too!).
+//!
+//! ```rust
+//! # #[cfg(any())] macro_rules! ignore {
+#![doc = stringified_module_code!()]
+//! # }
+#![allow(warnings, clippy::all)]
+
+use_libc_or_else! {
+    pub use ::libc::{
+        /// Note: your should probably be using [`crate::c_char`] instead.
+        c_char else u8,
+        /// Note: your should probably be using [`crate::c_int`] instead.
+        c_int else ::core::ffi::c_int,
+        ///
+        size_t else usize,
+        ///
+        uintptr_t else usize,
+    };
+}
+
+macro_rules! use_libc_or_else_ {(
+    pub use ::libc::{
+        $(
+            $(#$doc:tt)*
+            $c_type:ident else $FallbackTy:ty
+        ),* $(,)?
+    };
+) => (
+
+    $(
+        #[doc = concat!("A _`type` alias_ to [`::libc::", stringify!($c_type), "`].")]
+        ///
+        $(#$doc)*
+        pub type $c_type = helper::$c_type;
+    )*
+
+    mod helper {
+        mod real_libc {
+            pub use ::libc::*;
+            $(
+                pub const $c_type: () = ();
+            )*
+        }
+
+        pub use real_libc::{
+            $(
+                $c_type,
+            )*
+        };
+
+        pub use fallback::*;
+        mod fallback {
+            $(
+                pub type $c_type = $FallbackTy;
+            )*
+        }
+    }
+)} use use_libc_or_else_;
+
+macro_rules! use_libc_or_else {(
+    $($input:tt)*
+) => (
+    macro_rules! stringified_module_code {() => (
+        stringify!($($input)*)
+    )}
+
+    use_libc_or_else_!($($input)*);
+)} use use_libc_or_else;

--- a/src/proc_macro/Cargo.toml
+++ b/src/proc_macro/Cargo.toml
@@ -4,7 +4,7 @@ proc-macro = true
 
 [package]
 name = "safer_ffi-proc_macros"
-version = "0.1.1"  # Keep in sync
+version = "0.1.2"  # Keep in sync
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2021"
 

--- a/src/utils/prelude.rs
+++ b/src/utils/prelude.rs
@@ -27,7 +27,7 @@ cfg_match! {
         pub(in crate) type size_t = u32;
     },
     _ => {
-        pub(in crate) use ::libc::size_t;
+        pub(in crate) use crate::libc::size_t;
     },
 }
 


### PR DESCRIPTION
<img width="1088" alt="Screenshot 2023-07-07 at 16 42 50" src="https://github.com/getditto/safer_ffi/assets/9920355/aefa3050-a62a-426b-8de1-185cefc285ae">

  - automagical fallback implementation for atypical platforms;
  - reëxported at the root of the crate for convenience;
  - unhide the `c_int` reëxport.

Fixes #168 