### PR TITLE
Improve the `ffi_await!` situation: mainly, the UX on syntax error

### DIFF
--- a/src/_lib.rs
+++ b/src/_lib.rs
@@ -660,4 +660,10 @@ mod __ {
             }
         }
     }
+
+    #[doc(hidden)] /** Not part of the public API! */
+    #[macro_export]
+    macro_rules! ඞassert_expr {( $e:expr $(,)? ) => ( $e )}
+    #[doc(inline)]
+    pub use ඞassert_expr as assert_expr;
 }

--- a/src/proc_macro/utils/macros.rs
+++ b/src/proc_macro/utils/macros.rs
@@ -1,15 +1,20 @@
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-macro_rules! spanned {( $span:expr $(,)? ) => (
-    ::proc_macro2::Ident::new("__", $span)
-)} pub(in crate) use spanned;
+pub(in crate)
+fn reified_span(span: impl Into<Option<::proc_macro2::Span>>)
+  -> impl ::quote::ToTokens
+{
+    ::proc_macro2::Ident::new("__", span.into().unwrap_or_else(
+        ::proc_macro2::Span::call_site
+    ))
+}
 
 macro_rules! bail {
     (
         $err_msg:expr $(,)?
     ) => (
         $crate::utils::bail! {
-            $err_msg => $crate::utils::spanned!(::proc_macro2::Span::call_site())
+            $err_msg => $crate::utils::reified_span(::core::prelude::v1::None)
         }
     );
 


### PR DESCRIPTION
#### Before

<img width="1240" alt="Screenshot 2023-07-26 at 13 54 20" src="https://github.com/getditto/safer_ffi/assets/9920355/01011d1e-293f-48fe-892d-086f5cb33e25">

#### Now

<img width="894" alt="Screenshot 2023-07-26 at 13 55 05" src="https://github.com/getditto/safer_ffi/assets/9920355/ec208a5d-9505-4d35-a640-448d4516b1b3">

cc @connorpower 