### PR TITLE
Fix docs: `#[ReprC::opaque]` was replaced with `#[repr(opaque)]`

### DIFF
--- a/guide/src/derive-reprc/_.md
+++ b/guide/src/derive-reprc/_.md
@@ -67,7 +67,7 @@ Currently, the supported types for the attribute are:
     use ::safer_ffi::prelude::*;
 
     #[derive_ReprC]
-    #[ReprC::opaque]
+    #[repr(opaque)]
     struct MyOpaque {
         /* anything goes here */
     }

--- a/guide/src/derive-reprc/struct.md
+++ b/guide/src/derive-reprc/struct.md
@@ -105,7 +105,7 @@ and function abstraction:
 
 ```rust,noplaypen
 #[derive_ReprC]
-#[ReprC::opaque] // <-- instead of `#[repr(C)]`
+#[repr(opaque)] // <-- instead of `#[repr(C)]`
 pub
 struct ComplicatedStruct {
     path: PathBuf,
@@ -132,7 +132,7 @@ use ::std::{
 use ::safer_ffi::prelude::*;
 
 #[derive_ReprC]
-#[ReprC::opaque]
+#[repr(opaque)]
 pub
 struct ComplicatedStruct {
     path: PathBuf,


### PR DESCRIPTION
Updates some remaining `#[ReprC::opaque]` instances that were missed in https://github.com/getditto/safer_ffi/commit/65a8a2d8ccfd5ef5b5f58a495bc8cea9da07c6fc .
 