### PR TITLE
Implement Clone as expected for Copy types

### DIFF
--- a/src/proc_macro/derives/repr_c/struct_.rs
+++ b/src/proc_macro/derives/repr_c/struct_.rs
@@ -473,7 +473,7 @@ fn derive_opaque (
                 fn clone (self: &'_ Self)
                   -> Self
                 {
-                    match self._void {}
+                    *self
                 }
             }
 


### PR DESCRIPTION
This addresses the clippy lint `incorrect_clone_impl_on_copy_type`.
Resolves #181 