### PR TITLE
Rename 'cfg_match' to 'match_cfg' to avoid collision of std nightly macro with the same name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 **/*.rs.bk
 .DS_Store
 *.code-workspace
+filename.h
+generated.cffi
+generated.cs
+generated.h

--- a/src/_lib.rs
+++ b/src/_lib.rs
@@ -226,7 +226,7 @@ pub use ::safer_ffi_proc_macros::derive_ReprC;
 pub mod layout;
 
 __cfg_headers__! {
-    cfg_match! {
+    match_cfg! {
         feature = "inventory-0-3-1" => {
             #[doc(hidden)] pub
             use ::inventory_0_3_1 as inventory;
@@ -509,7 +509,7 @@ mod __ {
         },
     };
 
-    cfg_match! {
+    match_cfg! {
         feature = "std" => {
             pub use ::std::{*,
                 self,
@@ -552,7 +552,7 @@ mod __ {
         type ItSelf = Self;
     }
 
-    cfg_match! {
+    match_cfg! {
         feature = "log" => {
             #[apply(hidden_export)]
             macro_rules! __error__ {( $($msg:tt)* ) => (

--- a/src/dyn_traits/futures/executor.rs
+++ b/src/dyn_traits/futures/executor.rs
@@ -141,7 +141,7 @@ match_! {([] [Send + Sync]) {( $([ $($SendSync:tt)* ])* ) => (
     )*
 )}}
 
-cfg_match!(feature = "tokio" => {
+match_cfg!(feature = "tokio" => {
     #[cfg_attr(all(docs, feature = "nightly"),
         doc(cfg(feature = "tokio"))
     )]

--- a/src/layout/macros.rs
+++ b/src/layout/macros.rs
@@ -16,7 +16,7 @@ macro_rules! export_cfgs {(
     ),* $(,)?
 ) => (
     $(
-        cfg_match! {
+        match_cfg! {
             feature = $feature => {
                 #[doc(hidden)] /** not part of the public API */ #[macro_export]
                 macro_rules! $macro_name {(
@@ -52,7 +52,7 @@ macro_rules! export_cfgs {(
 //     }
 // })
 // ```
-cfg_match! {
+match_cfg! {
     feature = "python-headers" => {
         #[doc(hidden)] /** Not part of the public API */ #[macro_export]
         macro_rules! __with_cfg_python__ {(

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -7,7 +7,7 @@ macro_rules! use_prelude { () => (
 )}
 
 /// I really don't get the complexity of `cfg_if!`…
-macro_rules! cfg_match {
+macro_rules! match_cfg {
     (
         _ => { $($expansion:tt)* } $(,)?
     ) => (
@@ -19,21 +19,21 @@ macro_rules! cfg_match {
         $($($rest:tt)+)? )?
     ) => (
         #[cfg($cfg)]
-        cfg_match! { _ => $expansion } $($(
+        match_cfg! { _ => $expansion } $($(
 
         #[cfg(not($cfg))]
-        cfg_match! { $($rest)+ } )?)?
+        match_cfg! { $($rest)+ } )?)?
     );
 
-    // Bonus: expression-friendly syntax: `cfg_match!({ … })`
+    // Bonus: expression-friendly syntax: `match_cfg!({ … })`
     ({
         $($input:tt)*
     }) => ({
-        cfg_match! { $($input)* }
+        match_cfg! { $($input)* }
     });
 }
 
-cfg_match! {
+match_cfg! {
     feature = "alloc" => {
         macro_rules! cfg_alloc {(
             $($item:item)*
@@ -53,7 +53,7 @@ cfg_match! {
     },
 }
 
-cfg_match! {
+match_cfg! {
     feature = "std" => {
         macro_rules! cfg_std {(
             $($item:item)*

--- a/src/utils/prelude.rs
+++ b/src/utils/prelude.rs
@@ -21,7 +21,7 @@ pub(in crate) use ::core::{
     },
 };
 
-cfg_match! {
+match_cfg! {
     target_arch = "wasm32" => {
         #[allow(bad_style, dead_code)]
         pub(in crate) type size_t = u32;


### PR DESCRIPTION
 Fixes #191.