### PR TITLE
[C#] Specify the complete path for the Rust Lib - to be used on .NET >= 6 iOS

### DIFF
--- a/src/headers/templates/csharp/_prelude.cs
+++ b/src/headers/templates/csharp/_prelude.cs
@@ -11,5 +11,9 @@ using System;
 using System.Runtime.InteropServices;
 
 public unsafe partial class Ffi {{
+#if IOS
+    private const string RustLib = "{RustLib}.framework/{RustLib}";
+#else 
     private const string RustLib = "{RustLib}";
+#endif
 }}


### PR DESCRIPTION
**Context**: Normally you can use a tool like DLLMap to adjust that (on Mono-based projects, like Xamarin). However, with .NET >= 6 iOS there's no DLL map.

You can use the new .NET APIs https://github.com/dotnet/runtime/blob/main/docs/design/features/dllmap.md but that would be problematic for some SDKs - You'd need to have an "entry point" for resolving the DLL in code, before any public method using the FFI would be invoked.