### PR TITLE
Allow `VirtualPtr` to be `Option`-wrapped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-compat",
  "cratesio-placeholder-package",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ path = "src/_lib.rs"
 
 [package]
 name = "safer-ffi"
-version = "0.1.4"  # Keep in sync
+version = "0.1.5"  # Keep in sync
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
@@ -164,7 +164,7 @@ version = "0.0.3"
 
 [dependencies.safer_ffi-proc_macros]
 path = "src/proc_macro"
-version = "=0.1.4"  # Keep in sync
+version = "=0.1.5"  # Keep in sync
 
 [workspace]
 members = [

--- a/ffi_tests/Cargo.lock
+++ b/ffi_tests/Cargo.lock
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "futures",
  "inventory",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/js_tests/Cargo.lock
+++ b/js_tests/Cargo.lock
@@ -557,7 +557,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "cratesio-placeholder-package",
  "inventory",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/src/dyn_traits/_mod.rs
+++ b/src/dyn_traits/_mod.rs
@@ -115,6 +115,8 @@ impl<DynTrait : ?Sized + DynClone> Clone for VirtualPtr<DynTrait> {
 
 use hack::VirtualPtr_;
 mod hack {
+    use ::safer_ffi::layout;
+
     #[super::derive_ReprC]
     #[repr(C)]
     #[allow(missing_debug_implementations)]
@@ -122,6 +124,22 @@ mod hack {
     struct VirtualPtr_<Ptr, VTable> {
         pub(in super) ptr: Ptr,
         pub(in super) vtable: VTable,
+    }
+
+    unsafe
+    impl<Ptr, VTable>
+        layout::__HasNiche__
+    for
+        VirtualPtr_<Ptr, VTable>
+    where
+        Ptr : layout::ConcreteReprC + layout::__HasNiche__,
+        VTable : layout::ConcreteReprC,
+    {
+        fn is_niche (it: &'_ <Self as super::ReprC>::CLayout)
+          -> bool
+        {
+            Ptr::is_niche(&it.ptr)
+        }
     }
 }
 

--- a/src/proc_macro/Cargo.toml
+++ b/src/proc_macro/Cargo.toml
@@ -4,7 +4,7 @@ proc-macro = true
 
 [package]
 name = "safer_ffi-proc_macros"
-version = "0.1.4"  # Keep in sync
+version = "0.1.5"  # Keep in sync
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2021"
 


### PR DESCRIPTION
By relying on the non-nullability of its `.ptr` field.