### PR TITLE
Remove `inventory v0.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,12 +71,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.26"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+checksum = "ad291aa74992b9b7a7e88c38acbbf6ad7e107f1d90ee8775b7bc1fc3394f485c"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -96,7 +96,7 @@ checksum = "1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -183,7 +183,7 @@ checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -218,13 +218,13 @@ dependencies = [
 
 [[package]]
 name = "ghost"
-version = "0.1.8"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e0cd8a998937e25c6ba7cc276b96ec5cc3f4dc4ab5de9ede4fb152bdd5c5eb"
+checksum = "b0e085ded9f1267c32176b40921b9754c474f7dd96f7e808d4a982e48aa1e854"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498ae1c9c329c7972b917506239b557a60386839192f1cf0ca034f345b65db99"
+checksum = "7741301a6d6a9b28ce77c0fb77a4eb116b6bc8f3bef09923f7743d059c4157d3"
 dependencies = [
  "ctor",
  "ghost",
@@ -368,7 +368,7 @@ source = "git+https://github.com/getditto/napi-rs?branch=ditto/closure-into-jsfu
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -385,7 +385,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -407,7 +407,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -462,23 +462,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebcd279d20a4a0a2404a33056388e950504d891c855c7975b9a8fef75f3bf04"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -500,7 +500,7 @@ checksum = "9c501201393982e275433bc55de7d6ae6f00e7699cd5572c5b57581cd69c881b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -573,7 +573,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -609,7 +609,7 @@ checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -643,6 +643,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -766,7 +777,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -800,7 +811,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -945,5 +956,5 @@ checksum = "15bd7679c15e22924f53aee34d4e448c45b674feb6129689af88593e129f8f42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-compat",
  "cratesio-placeholder-package",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,34 +261,12 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb5160c60ba1e809707918ee329adb99d222888155835c6feedba19f6c3fd4"
-dependencies = [
- "ctor",
- "ghost",
- "inventory-impl",
-]
-
-[[package]]
-name = "inventory"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498ae1c9c329c7972b917506239b557a60386839192f1cf0ca034f345b65db99"
 dependencies = [
  "ctor",
  "ghost",
-]
-
-[[package]]
-name = "inventory-impl"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -565,8 +543,7 @@ dependencies = [
  "async-compat",
  "cratesio-placeholder-package",
  "futures",
- "inventory 0.1.11",
- "inventory 0.3.4",
+ "inventory",
  "libc",
  "log",
  "macro_rules_attribute",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ futures.optional = true
 futures.version = "0.3.24"
 
 inventory.optional = true
-inventory.version = "0.3.1"
+inventory.version = "0.3.5"
 
 libc.version = "0.2.66"
 libc.default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ path = "src/_lib.rs"
 
 [package]
 name = "safer-ffi"
-version = "0.1.6"  # Keep in sync
+version = "0.1.7"  # Keep in sync
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
@@ -159,7 +159,7 @@ version = "0.0.3"
 
 [dependencies.safer_ffi-proc_macros]
 path = "src/proc_macro"
-version = "=0.1.6"  # Keep in sync
+version = "=0.1.7"  # Keep in sync
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,11 +95,6 @@ js = [
     "std",
 ]
 
-inventory-0-3-1 = [
-    "dep:inventory-0-3-1",
-    "safer_ffi-proc_macros/inventory-0-3-1",
-]
-
 internal-tests = [
     "async-fn",
     "headers",
@@ -120,11 +115,7 @@ futures.optional = true
 futures.version = "0.3.24"
 
 inventory.optional = true
-inventory.version = "0.1.6"
-
-inventory-0-3-1.optional = true
-inventory-0-3-1.package = "inventory"
-inventory-0-3-1.version = "0.3.1"
+inventory.version = "0.3.1"
 
 libc.version = "0.2.66"
 libc.default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,10 @@ js = [
     "std",
 ]
 
+# Deprecated: now always enabled, and thus does nothing.
+# TODO: remove in the next semver bump.
+inventory-0-3-1 = []
+
 internal-tests = [
     "async-fn",
     "headers",

--- a/ffi_tests/Cargo.lock
+++ b/ffi_tests/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "ctor"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad291aa74992b9b7a7e88c38acbbf6ad7e107f1d90ee8775b7bc1fc3394f485c"
+dependencies = [
+ "quote",
+ "syn 2.0.12",
+]
+
+[[package]]
 name = "ext-trait"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,7 +35,7 @@ checksum = "1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -101,7 +111,7 @@ checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -135,10 +145,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "inventory"
-version = "0.3.15"
+name = "ghost"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
+checksum = "fae7e09da323fc46f010e455cac340af26159678ba00ab18e963a5880ca6a9b6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.12",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7741301a6d6a9b28ce77c0fb77a4eb116b6bc8f3bef09923f7743d059c4157d3"
+dependencies = [
+ "ctor",
+ "ghost",
+]
 
 [[package]]
 name = "libc"
@@ -193,7 +218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebcd279d20a4a0a2404a33056388e950504d891c855c7975b9a8fef75f3bf04"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -238,7 +263,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -261,6 +286,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -305,5 +341,5 @@ checksum = "15bd7679c15e22924f53aee34d4e448c45b674feb6129689af88593e129f8f42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]

--- a/ffi_tests/Cargo.lock
+++ b/ffi_tests/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "futures",
  "inventory",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/ffi_tests/Cargo.lock
+++ b/ffi_tests/Cargo.lock
@@ -9,16 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "ext-trait"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,37 +135,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghost"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e0cd8a998937e25c6ba7cc276b96ec5cc3f4dc4ab5de9ede4fb152bdd5c5eb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "inventory"
-version = "0.1.11"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb5160c60ba1e809707918ee329adb99d222888155835c6feedba19f6c3fd4"
-dependencies = [
- "ctor",
- "ghost",
- "inventory-impl",
-]
-
-[[package]]
-name = "inventory-impl"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "libc"

--- a/ffi_tests/generated.cs
+++ b/ffi_tests/generated.cs
@@ -20,7 +20,11 @@ using System;
 using System.Runtime.InteropServices;
 
 public unsafe partial class Ffi {
+#if IOS
+    private const string RustLib = "ffi_tests.framework/ffi_tests";
+#else
     private const string RustLib = "ffi_tests";
+#endif
 }
 
 public enum Wow_t : byte {

--- a/js_tests/Cargo.lock
+++ b/js_tests/Cargo.lock
@@ -67,6 +67,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad291aa74992b9b7a7e88c38acbbf6ad7e107f1d90ee8775b7bc1fc3394f485c"
+dependencies = [
+ "quote",
+ "syn 2.0.12",
+]
+
+[[package]]
 name = "ext-trait"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,7 +93,7 @@ checksum = "1ab7934152eaf26aa5aa9f7371408ad5af4c31357073c9e84c3b9d7f11ad639a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -170,7 +180,7 @@ checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -201,6 +211,17 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "ghost"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fae7e09da323fc46f010e455cac340af26159678ba00ab18e963a5880ca6a9b6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -237,9 +258,13 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.15"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
+checksum = "7741301a6d6a9b28ce77c0fb77a4eb116b6bc8f3bef09923f7743d059c4157d3"
+dependencies = [
+ "ctor",
+ "ghost",
+]
 
 [[package]]
 name = "itoa"
@@ -350,7 +375,7 @@ source = "git+https://github.com/getditto/napi-rs?branch=ditto/closure-into-jsfu
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -367,7 +392,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -389,7 +414,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -444,7 +469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebcd279d20a4a0a2404a33056388e950504d891c855c7975b9a8fef75f3bf04"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -482,7 +507,7 @@ checksum = "9c501201393982e275433bc55de7d6ae6f00e7699cd5572c5b57581cd69c881b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -550,7 +575,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -586,7 +611,7 @@ checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -620,6 +645,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -743,7 +779,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -777,7 +813,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -922,5 +958,5 @@ checksum = "15bd7679c15e22924f53aee34d4e448c45b674feb6129689af88593e129f8f42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]

--- a/js_tests/Cargo.lock
+++ b/js_tests/Cargo.lock
@@ -520,7 +520,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "cratesio-placeholder-package",
  "inventory",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/js_tests/Cargo.lock
+++ b/js_tests/Cargo.lock
@@ -67,16 +67,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "ext-trait"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,17 +204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghost"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e0cd8a998937e25c6ba7cc276b96ec5cc3f4dc4ab5de9ede4fb152bdd5c5eb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "gloo-utils"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,25 +237,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.1.11"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb5160c60ba1e809707918ee329adb99d222888155835c6feedba19f6c3fd4"
-dependencies = [
- "ctor",
- "ghost",
- "inventory-impl",
-]
-
-[[package]]
-name = "inventory-impl"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "itoa"

--- a/napi-dispatcher/nodejs-derive/src/proc_macros/mod.rs
+++ b/napi-dispatcher/nodejs-derive/src/proc_macros/mod.rs
@@ -92,9 +92,6 @@ fn js_export (
         )
     };
     let stmts = &fun.block.stmts;
-    let krate_annotation = cfg!(not(feature = "inventory-0-3-1")).then(|| {
-        quote!( #![crate = ::safer_ffi::js::registering] )
-    });
     let ret = quote!(
         const _: () = {
             #napi_import
@@ -109,8 +106,6 @@ fn js_export (
             }
 
             ::safer_ffi::js::registering::submit! {
-                #krate_annotation
-
                 ::safer_ffi::js::registering::NapiRegistryEntry::NamedMethod {
                     name: ::core::stringify!(#js_name),
                     method: #name,

--- a/src/_lib.rs
+++ b/src/_lib.rs
@@ -226,16 +226,8 @@ pub use ::safer_ffi_proc_macros::derive_ReprC;
 pub mod layout;
 
 __cfg_headers__! {
-    match_cfg! {
-        feature = "inventory-0-3-1" => {
-            #[doc(hidden)] pub
-            use ::inventory_0_3_1 as inventory;
-        },
-        _ => {
-            #[doc(hidden)] pub
-            use ::inventory;
-        },
-    }
+    #[doc(hidden)] pub
+    use ::inventory;
 
     #[cfg_attr(feature = "nightly",
         doc(cfg(feature = "headers")),

--- a/src/headers/templates/csharp/_prelude.cs
+++ b/src/headers/templates/csharp/_prelude.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 public unsafe partial class Ffi {{
 #if IOS
     private const string RustLib = "{RustLib}.framework/{RustLib}";
-#else 
+#else
     private const string RustLib = "{RustLib}";
 #endif
 }}

--- a/src/proc_macro/Cargo.toml
+++ b/src/proc_macro/Cargo.toml
@@ -4,7 +4,7 @@ proc-macro = true
 
 [package]
 name = "safer_ffi-proc_macros"
-version = "0.1.6"  # Keep in sync
+version = "0.1.7"  # Keep in sync
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2021"
 

--- a/src/proc_macro/Cargo.toml
+++ b/src/proc_macro/Cargo.toml
@@ -37,5 +37,3 @@ js = [
 verbose-expansions = [
     # "prettyplease",
 ]
-
-inventory-0-3-1 = []

--- a/src/proc_macro/ffi_export/const_.rs
+++ b/src/proc_macro/ffi_export/const_.rs
@@ -24,16 +24,11 @@ fn handle (
         let Ty @ _ = &input.ty;
         let ref each_doc = utils::extract_docs(&input.attrs)?;
 
-        let inventory_krate = cfg!(not(feature = "inventory-0-3-1")).then(|| {
-            quote!( #![crate = #ඞ] )
-        });
         Ok(quote!(
             #input
 
             #[cfg(not(target_arch = "wasm32"))]
             #ඞ::inventory::submit! {
-                #inventory_krate
-
                 #ඞ::FfiExport {
                     name: #VAR_str,
                     gen_def: |

--- a/src/proc_macro/ffi_export/fn_/mod.rs
+++ b/src/proc_macro/ffi_export/fn_/mod.rs
@@ -358,14 +358,9 @@ fn handle (
         let ref EachArgTy @ _ = arg_tys(&fun).vec();
         let each_doc = utils::extract_docs(&fun.attrs)?;
         let (generics, _, where_clause) = fun.sig.generics.split_for_impl();
-        let inventory_krate = cfg!(not(feature = "inventory-0-3-1")).then(|| {
-            quote!( #![crate = #ඞ] )
-        });
         ret.extend(quote!(
             #[cfg(not(target_arch = "wasm32"))]
             #ඞ::inventory::submit! {
-                #inventory_krate
-
                 #ඞ::FfiExport {
                     name: #export_name_str,
                     gen_def: {

--- a/src/proc_macro/ffi_export/type_.rs
+++ b/src/proc_macro/ffi_export/type_.rs
@@ -19,17 +19,12 @@ fn handle (
         }
     }
     let ref Ty_str @ _ = Ty.to_string();
-    let inventory_krate = cfg!(not(feature = "inventory-0-3-1")).then(|| {
-        quote!( #![crate = ::safer_ffi] )
-    });
     Ok(quote!(
         #input
 
         #[cfg(not(target_arch = "wasm32"))]
         ::safer_ffi::__cfg_headers__! {
             ::safer_ffi::inventory::submit! {
-                #inventory_krate
-
                 ::safer_ffi::FfiExport {
                     name: #Ty_str,
                     gen_def: ::safer_ffi::headers::__define_self__::<#Ty>,


### PR DESCRIPTION
Usage of that dependency was a relic from a low MSRV past which prevented me from bumping that without potentially inconvening users, within a semver-compatible bump.

The MSRV has long been bumped since, so there was literally no need to use `inventory 0.1`.

Good thing is, #132 had already introduced to opt into overriding in `safer-ffi` with a more modern `inventory` (for compatibility with Wasm).

So the fix was "just" a matter of const-folding away the `inventory`-dispatching branches in the code (mainly related to the change w.r.t. the `#![crate = …]` argument to the `::inventory::submit!` macro), and cleaning up the `.toml` and `match_cfg! use … as inventory` Cargo-feature dance.

  - Fixes #188

