### PR TITLE
Fix macro-not-found error with rust-nightly

### DIFF
--- a/src/libc.rs
+++ b/src/libc.rs
@@ -67,7 +67,7 @@ macro_rules! use_libc_or_else {(
 ) => (
     macro_rules! stringified_module_code {() => (
         stringify!($($input)*)
-    )}
+    )} use stringified_module_code;
 
     use_libc_or_else_!($($input)*);
 )} use use_libc_or_else;


### PR DESCRIPTION
Running `cargo test` fails complaining that the macro `stringified_module_code` cannot be found in this scope.

Version: rustc 1.80.0-nightly (e82c861d7 2024-05-04)

```
error: cannot find macro `stringified_module_code` in this scope
  --> src/libc.rs:9:10
   |
9  | #![doc = stringified_module_code!()]
   |          ^^^^^^^^^^^^^^^^^^^^^^^ consider moving the definition of `stringified_module_code` before this call
   |
note: a macro with the same name exists, but it appears later at here
  --> src/libc.rs:68:18
   |
68 |     macro_rules! stringified_module_code {() => (
   |                  ^^^^^^^^^^^^^^^^^^^^^^^
```

I am not sure because rules around macro scopes are somewhat complex, but it seems that the macro should not be found either with textual scope or path-based scope (none by default), so it looks like rustc fixed an implementation bug incorrectly allowing this macro to be found, but I could be wrong.