### PR TITLE
Added LanguageConfig concept, implemented function_macro_prepend option

### DIFF
--- a/ffi_tests/src/lib.rs
+++ b/ffi_tests/src/lib.rs
@@ -2,11 +2,6 @@
 #![allow(unused)]
 
 use ::safer_ffi::prelude::*;
-use ::safer_ffi::headers::languages::{
-    CLanguageConfig,
-    CSharpLanguageConfig,
-    PythonLanguageConfig
-};
 
 /// Concatenate the two input strings into a new one.
 ///
@@ -222,6 +217,11 @@ fn generate_headers ()
   -> ::std::io::Result<()>
 {
     use ::safer_ffi::headers::LanguageConfig::*;
+    use ::safer_ffi::headers::languages::{
+        CLanguageConfig,
+        CSharpLanguageConfig,
+        PythonLanguageConfig
+    };
     for (language, ext)
         in  [
                 (C(CLanguageConfig::default()), "h"),

--- a/ffi_tests/src/lib.rs
+++ b/ffi_tests/src/lib.rs
@@ -2,6 +2,11 @@
 #![allow(unused)]
 
 use ::safer_ffi::prelude::*;
+use ::safer_ffi::headers::languages::{
+    CLanguageConfig,
+    CSharpLanguageConfig,
+    PythonLanguageConfig
+};
 
 /// Concatenate the two input strings into a new one.
 ///
@@ -226,7 +231,7 @@ fn generate_headers ()
     {
         let builder =
             ::safer_ffi::headers::builder()
-                .with_language(language)
+                .with_language_config(language)
         ;
         if  ::std::env::var("HEADERS_TO_STDOUT")
                 .ok()

--- a/ffi_tests/src/lib.rs
+++ b/ffi_tests/src/lib.rs
@@ -216,7 +216,7 @@ pub struct AnUnusedStruct {
 fn generate_headers ()
   -> ::std::io::Result<()>
 {
-    use ::safer_ffi::headers::Language::*;
+    use ::safer_ffi::headers::LanguageConfig::*;
     for &(language, ext) in &[(C, "h"), (CSharp, "cs"), (Python, "cffi")] {
         let builder =
             ::safer_ffi::headers::builder()

--- a/ffi_tests/src/lib.rs
+++ b/ffi_tests/src/lib.rs
@@ -217,7 +217,13 @@ fn generate_headers ()
   -> ::std::io::Result<()>
 {
     use ::safer_ffi::headers::LanguageConfig::*;
-    for &(language, ext) in &[(C, "h"), (CSharp, "cs"), (Python, "cffi")] {
+    for (language, ext)
+        in  [
+                (C(CLanguageConfig::default()), "h"),
+                (CSharp(CSharpLanguageConfig::default()), "cs"),
+                (Python(PythonLanguageConfig::default()), "cffi")
+            ]
+    {
         let builder =
             ::safer_ffi::headers::builder()
                 .with_language(language)

--- a/src/_lib.rs
+++ b/src/_lib.rs
@@ -244,7 +244,7 @@ __cfg_headers__! {
 
         pub
         gen_def:
-            fn(&mut dyn headers::Definer, headers::Language)
+            fn(&mut dyn headers::Definer, &headers::LanguageConfig)
               -> std::io::Result<()>
         ,
     }
@@ -502,7 +502,7 @@ mod __ {
         crate::{
             headers::{
                 Definer,
-                Language,
+                LanguageConfig,
                 languages::{
                     self,
                     EnumVariant,

--- a/src/c_char.rs
+++ b/src/c_char.rs
@@ -69,6 +69,7 @@ impl LegacyCType
 
     fn c_define_self (
         _: &'_ mut dyn crate::headers::Definer,
+        _: &'_ crate::headers::LanguageConfig
     ) -> io::Result<()>
     {
         Ok(())
@@ -77,6 +78,7 @@ impl LegacyCType
     __cfg_csharp__! {
         fn csharp_define_self (
             _: &'_ mut dyn crate::headers::Definer,
+            _: &'_ crate::headers::LanguageConfig
         ) -> io::Result<()>
         {
             Ok(())

--- a/src/headers/languages/c.rs
+++ b/src/headers/languages/c.rs
@@ -40,6 +40,7 @@ impl HeaderLanguage for C {
             fn emit_type_alias(
                 self: &'_ Self,
                 ctx: &'_ mut dyn Definer,
+                lang_config: &'_ LanguageConfig,
                 docs: Docs<'_>,
                 self_ty: &'_ dyn PhantomCType,
                 inner_ty: &'_ dyn PhantomCType,
@@ -47,7 +48,7 @@ impl HeaderLanguage for C {
             {
                 let ref indent = Indentation::new(4 /* ctx.indent_width() */);
                 mk_out!(indent, ctx.out());
-                self.emit_docs(ctx, docs, indent)?;
+                self.emit_docs(ctx, lang_config, docs, indent)?;
                 let ref aliaser = self_ty.name(self);
                 let ref aliasee = inner_ty.name(self);
                 out!((
@@ -264,7 +265,7 @@ impl HeaderLanguage for C {
         let ref indent = Indentation::new(4 /* ctx.indent_width() */);
         mk_out!(indent, ctx.out());
 
-        self.emit_docs(ctx, docs, indent)?;
+        self.emit_docs(ctx, lang_config, docs, indent)?;
         if skip_type {
             out!((
                 "#define {name} {value:?}"

--- a/src/headers/languages/c.rs
+++ b/src/headers/languages/c.rs
@@ -174,6 +174,7 @@ impl HeaderLanguage for C {
         ret_ty: &'_ dyn PhantomCType,
     ) -> io::Result<()>
     {
+        let c_config = lang_config.unwrap_as_c_or_default();
         let ref indent = Indentation::new(4 /* ctx.indent_width() */);
 
         self.emit_docs(ctx, lang_config, docs, indent)?;
@@ -206,9 +207,14 @@ impl HeaderLanguage for C {
             String::from_utf8(buf).unwrap()
         };
 
+        let function_macro_prepend = match &c_config.function_macro_prepend {
+            Some(s) => format!("{} ", s),
+            _ => String::new()
+        };
+
         mk_out!(indent, ctx.out());
         out!(
-            ("{};"), ret_ty.name_wrapping_var(self, fn_sig_but_for_ret_type)
+            ("{}{};"), function_macro_prepend, ret_ty.name_wrapping_var(self, fn_sig_but_for_ret_type)
         );
 
         out!("\n");
@@ -239,12 +245,16 @@ impl HeaderLanguage for C {
     }
 }
 
+/// Configuration options for C header generation
+///
 #[derive(
     Debug, Default,
-    Copy, Clone,
+    Clone,
     PartialEq, Eq,
 )]
 pub
 struct CLanguageConfig {
-
+    /// Prepends each function definition with the specified macro
+    ///
+    pub function_macro_prepend: Option<String>
 }

--- a/src/headers/languages/c.rs
+++ b/src/headers/languages/c.rs
@@ -232,3 +232,13 @@ impl HeaderLanguage for C {
         Ok(())
     }
 }
+
+#[derive(
+    Debug, Default,
+    Copy, Clone,
+    PartialEq, Eq,
+)]
+pub
+struct CLanguageConfig {
+
+}

--- a/src/headers/languages/c.rs
+++ b/src/headers/languages/c.rs
@@ -9,6 +9,7 @@ impl HeaderLanguage for C {
     fn emit_docs (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        _lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         indent: &'_ Indentation,
     ) -> io::Result<()>
@@ -33,6 +34,7 @@ impl HeaderLanguage for C {
     fn emit_simple_enum (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
         backing_integer: Option<&dyn PhantomCType>,
@@ -46,7 +48,7 @@ impl HeaderLanguage for C {
             backing_integer.map(|it| it.name(self))
         ;
 
-        self.emit_docs(ctx, docs, indent)?;
+        self.emit_docs(ctx, lang_config, docs, indent)?;
 
         let ref short_name = self_ty.short_name();
         let ref full_ty_name = self_ty.name(self);
@@ -65,7 +67,7 @@ impl HeaderLanguage for C {
 
         if let _ = indent.scope() {
             for v in variants {
-                self.emit_docs(ctx, v.docs, indent)?;
+                self.emit_docs(ctx, lang_config, v.docs, indent)?;
                 let variant_name = crate::utils::screaming_case(short_name, v.name) /* ctx.adjust_variant_name(
                     Language::C,
                     enum_name,
@@ -98,6 +100,7 @@ impl HeaderLanguage for C {
     fn emit_struct (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
         fields: &'_ [StructField<'_>]
@@ -112,7 +115,7 @@ impl HeaderLanguage for C {
             panic!("C does not support zero-sized structs!")
         }
 
-        self.emit_docs(ctx, docs, indent)?;
+        self.emit_docs(ctx, lang_config, docs, indent)?;
         out!(("typedef struct {short_name} {{"));
         if let _ = indent.scope() {
             let ref mut first = true;
@@ -128,7 +131,7 @@ impl HeaderLanguage for C {
                 if mem::take(first).not() {
                     out!("\n");
                 }
-                self.emit_docs(ctx, docs, indent)?;
+                self.emit_docs(ctx, lang_config, docs, indent)?;
                 out!(
                     ("{};"),
                     ty.name_wrapping_var(self, name)
@@ -144,6 +147,7 @@ impl HeaderLanguage for C {
     fn emit_opaque_type (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
     ) -> io::Result<()>
@@ -153,7 +157,7 @@ impl HeaderLanguage for C {
         let short_name = self_ty.short_name();
         let full_ty_name = self_ty.name(self);
 
-        self.emit_docs(ctx, docs, indent)?;
+        self.emit_docs(ctx, lang_config, docs, indent)?;
         out!(("typedef struct {short_name} {full_ty_name};"));
 
         out!("\n");
@@ -163,6 +167,7 @@ impl HeaderLanguage for C {
     fn emit_function (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         fname: &'_ str,
         args: &'_ [FunctionArg<'_>],
@@ -171,7 +176,7 @@ impl HeaderLanguage for C {
     {
         let ref indent = Indentation::new(4 /* ctx.indent_width() */);
 
-        self.emit_docs(ctx, docs, indent)?;
+        self.emit_docs(ctx, lang_config, docs, indent)?;
 
         let ref fn_sig_but_for_ret_type: String = {
             let mut buf = Vec::<u8>::new();
@@ -213,6 +218,7 @@ impl HeaderLanguage for C {
     fn emit_constant (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         name: &'_ str,
         ty: &'_ dyn PhantomCType,
@@ -222,7 +228,7 @@ impl HeaderLanguage for C {
         let ref indent = Indentation::new(4 /* ctx.indent_width() */);
         mk_out!(indent, ctx.out());
 
-        self.emit_docs(ctx, docs, indent)?;
+        self.emit_docs(ctx, lang_config, docs, indent)?;
         let ty = ty.name(self);
         out!((
             "#define {name} (({ty}) {value:?})"

--- a/src/headers/languages/csharp.rs
+++ b/src/headers/languages/csharp.rs
@@ -9,6 +9,7 @@ impl HeaderLanguage for CSharp {
     fn emit_docs (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        _lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         indent: &'_ Indentation,
     ) -> io::Result<()>
@@ -53,6 +54,7 @@ impl HeaderLanguage for CSharp {
     fn emit_simple_enum (
         self: &'_ CSharp,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
         backing_integer: Option<&dyn PhantomCType>,
@@ -68,7 +70,7 @@ impl HeaderLanguage for CSharp {
 
         let ref full_ty_name = self_ty.name(self);
 
-        self.emit_docs(ctx, docs, indent)?;
+        self.emit_docs(ctx, lang_config, docs, indent)?;
 
         out!(
             ("public enum {full_ty_name} {super} {{"),
@@ -81,7 +83,7 @@ impl HeaderLanguage for CSharp {
 
         if let _ = indent.scope() {
             for v in variants {
-                self.emit_docs(ctx, v.docs, indent)?;
+                self.emit_docs(ctx, lang_config, v.docs, indent)?;
                 let variant_name = v.name /* ctx.adjust_variant_name(
                     Language::CSharp,
                     enum_name,
@@ -104,6 +106,7 @@ impl HeaderLanguage for CSharp {
     fn emit_struct (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
         fields: &'_ [StructField<'_>]
@@ -119,7 +122,7 @@ impl HeaderLanguage for CSharp {
 
         let ref name = self_ty.name(self);
 
-        self.emit_docs(ctx, docs, indent)?;
+        self.emit_docs(ctx, lang_config, docs, indent)?;
         out!((
             "[StructLayout(LayoutKind.Sequential, Size = {size})]"
             "public unsafe struct {name} {{"
@@ -138,7 +141,7 @@ impl HeaderLanguage for CSharp {
                 if mem::take(first).not() {
                     out!("\n");
                 }
-                self.emit_docs(ctx, docs, indent)?;
+                self.emit_docs(ctx, lang_config, docs, indent)?;
                 if let Some(csharp_marshaler) = ty.csharp_marshaler() {
                     out!((
                         "[MarshalAs({csharp_marshaler})]"
@@ -159,6 +162,7 @@ impl HeaderLanguage for CSharp {
     fn emit_opaque_type (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
     ) -> io::Result<()>
@@ -168,7 +172,7 @@ impl HeaderLanguage for CSharp {
 
         let full_ty_name = self_ty.name(self);
 
-        self.emit_docs(ctx, docs, indent)?;
+        self.emit_docs(ctx, lang_config, docs, indent)?;
         out!(("public struct {full_ty_name} {{"));
         if let _ = indent.scope() {
             out!((
@@ -186,6 +190,7 @@ impl HeaderLanguage for CSharp {
     fn emit_function (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         fname: &'_ str,
         args: &'_ [FunctionArg<'_>],
@@ -200,7 +205,7 @@ impl HeaderLanguage for CSharp {
         ));
 
         if let _ = indent.scope() {
-            self.emit_docs(ctx, docs, indent)?;
+            self.emit_docs(ctx, lang_config, docs, indent)?;
 
             if let Some(marshaler) = ret_ty.csharp_marshaler() {
                 out!((
@@ -241,6 +246,7 @@ impl HeaderLanguage for CSharp {
     fn emit_constant (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         name: &'_ str,
         ty: &'_ dyn PhantomCType,
@@ -252,7 +258,7 @@ impl HeaderLanguage for CSharp {
 
         out!(("public unsafe partial class Ffi {{"));
         if let _ = indent.scope() {
-            self.emit_docs(ctx, docs, indent)?;
+            self.emit_docs(ctx, lang_config, docs, indent)?;
             let ty = ty.name(self);
             out!((
                 "public const {ty} {name} = {value:?};"

--- a/src/headers/languages/csharp.rs
+++ b/src/headers/languages/csharp.rs
@@ -271,6 +271,8 @@ impl HeaderLanguage for CSharp {
     }
 }
 
+/// Configuration options for CSharp header generation
+///
 #[derive(
     Debug, Default,
     Copy, Clone,

--- a/src/headers/languages/csharp.rs
+++ b/src/headers/languages/csharp.rs
@@ -264,3 +264,13 @@ impl HeaderLanguage for CSharp {
         Ok(())
     }
 }
+
+#[derive(
+    Debug, Default,
+    Copy, Clone,
+    PartialEq, Eq,
+)]
+pub
+struct CSharpLanguageConfig {
+
+}

--- a/src/headers/languages/mod.rs
+++ b/src/headers/languages/mod.rs
@@ -9,6 +9,7 @@ use {
     },
     super::{
         Definer,
+        LanguageConfig
     },
 };
 
@@ -71,6 +72,7 @@ trait HeaderLanguage : UpcastAny {
     fn emit_simple_enum (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
         backing_integer: Option<&'_ dyn PhantomCType>,
@@ -81,6 +83,7 @@ trait HeaderLanguage : UpcastAny {
     fn emit_struct (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
         fields: &'_ [StructField<'_>]
@@ -90,6 +93,7 @@ trait HeaderLanguage : UpcastAny {
     fn emit_opaque_type (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
     ) -> io::Result<()>
@@ -98,6 +102,7 @@ trait HeaderLanguage : UpcastAny {
     fn emit_function (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         fname: &'_ str,
         args: &'_ [FunctionArg<'_>],
@@ -108,6 +113,7 @@ trait HeaderLanguage : UpcastAny {
     fn emit_constant (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         name: &'_ str,
         ty: &'_ dyn PhantomCType,
@@ -118,6 +124,7 @@ trait HeaderLanguage : UpcastAny {
     fn emit_docs (
         self: &'_ Self,
         _ctx: &'_ mut dyn Definer,
+        _lang_config: &'_ LanguageConfig,
         _docs: Docs<'_>,
         _indentation: &'_ Indentation,
     ) -> io::Result<()>
@@ -189,7 +196,7 @@ trait PhantomCType {
 
     fn name (
         self: &'_ Self,
-        language: &'_ dyn HeaderLanguage,
+        language: &'_ dyn HeaderLanguage
     ) -> String
     ;
 
@@ -234,7 +241,7 @@ where
 
     fn name (
         self: &'_ Self,
-        language: &'_ dyn HeaderLanguage,
+        language: &'_ dyn HeaderLanguage
     ) -> String
     {
         T::name(language)

--- a/src/headers/languages/mod.rs
+++ b/src/headers/languages/mod.rs
@@ -12,16 +12,16 @@ use {
     },
 };
 
-pub use c::C;
+pub use c::{C, CLanguageConfig};
 mod c;
 
 __cfg_csharp__! {
-    pub use csharp::CSharp;
+    pub use csharp::{CSharp, CSharpLanguageConfig};
     mod csharp;
 }
 
 __cfg_python__! {
-    pub use python::Python;
+    pub use python::{Python, PythonLanguageConfig};
     mod python;
 }
 

--- a/src/headers/languages/mod.rs
+++ b/src/headers/languages/mod.rs
@@ -147,6 +147,7 @@ trait HeaderLanguageSupportingTypeAliases : HeaderLanguage {
     fn emit_type_alias(
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ LanguageConfig,
         docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
         inner_ty: &'_ dyn PhantomCType,

--- a/src/headers/languages/python.rs
+++ b/src/headers/languages/python.rs
@@ -11,6 +11,7 @@ impl HeaderLanguage for Python {
     fn emit_docs (
         self: &'_ Self,
         _ctx: &'_ mut dyn Definer,
+        _lang_config: &'_ &LanguageConfig,
         _docs: Docs<'_>,
         _indent: &'_ Indentation,
     ) -> io::Result<()>
@@ -22,6 +23,7 @@ impl HeaderLanguage for Python {
     fn emit_simple_enum (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ &LanguageConfig,
         _docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
         _backing_integer: Option<&dyn PhantomCType>,
@@ -40,7 +42,7 @@ impl HeaderLanguage for Python {
             for v in variants {
                 self.emit_docs(ctx, v.docs, indent)?;
                 let variant_name = crate::utils::screaming_case(short_name, v.name) /* ctx.adjust_variant_name(
-                    Language::C,
+                    LanguageConfig::C,
                     enum_name,
                     v.name,
                 ) */;
@@ -56,6 +58,7 @@ impl HeaderLanguage for Python {
     fn emit_struct (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ &LanguageConfig,
         _docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
         fields: &'_ [StructField<'_>]
@@ -101,6 +104,7 @@ impl HeaderLanguage for Python {
     fn emit_opaque_type (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ &LanguageConfig,
         _docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
     ) -> io::Result<()>
@@ -116,6 +120,7 @@ impl HeaderLanguage for Python {
     fn emit_function (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ &LanguageConfig,
         _docs: Docs<'_>,
         fname: &'_ str,
         args: &'_ [FunctionArg<'_>],
@@ -157,6 +162,7 @@ impl HeaderLanguage for Python {
     fn emit_constant (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
+        lang_config: &'_ &LanguageConfig,
         _docs: Docs<'_>,
         name: &'_ str,
         _ty: &'_ dyn PhantomCType,

--- a/src/headers/languages/python.rs
+++ b/src/headers/languages/python.rs
@@ -174,3 +174,13 @@ impl HeaderLanguage for Python {
         Ok(())
     }
 }
+
+#[derive(
+    Debug, Default,
+    Copy, Clone,
+    PartialEq, Eq,
+)]
+pub
+struct PythonLanguageConfig {
+
+}

--- a/src/headers/languages/python.rs
+++ b/src/headers/languages/python.rs
@@ -181,6 +181,8 @@ impl HeaderLanguage for Python {
     }
 }
 
+/// Configuration options for Python header generation
+///
 #[derive(
     Debug, Default,
     Copy, Clone,

--- a/src/headers/languages/python.rs
+++ b/src/headers/languages/python.rs
@@ -11,7 +11,7 @@ impl HeaderLanguage for Python {
     fn emit_docs (
         self: &'_ Self,
         _ctx: &'_ mut dyn Definer,
-        _lang_config: &'_ &LanguageConfig,
+        _lang_config: &'_ LanguageConfig,
         _docs: Docs<'_>,
         _indent: &'_ Indentation,
     ) -> io::Result<()>
@@ -23,7 +23,7 @@ impl HeaderLanguage for Python {
     fn emit_simple_enum (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
-        lang_config: &'_ &LanguageConfig,
+        lang_config: &'_ LanguageConfig,
         _docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
         _backing_integer: Option<&dyn PhantomCType>,
@@ -40,7 +40,7 @@ impl HeaderLanguage for Python {
 
         if let _ = indent.scope() {
             for v in variants {
-                self.emit_docs(ctx, v.docs, indent)?;
+                self.emit_docs(ctx, lang_config, v.docs, indent)?;
                 let variant_name = crate::utils::screaming_case(short_name, v.name) /* ctx.adjust_variant_name(
                     LanguageConfig::C,
                     enum_name,
@@ -58,7 +58,7 @@ impl HeaderLanguage for Python {
     fn emit_struct (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
-        lang_config: &'_ &LanguageConfig,
+        lang_config: &'_ LanguageConfig,
         _docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
         fields: &'_ [StructField<'_>]
@@ -88,7 +88,7 @@ impl HeaderLanguage for Python {
                 if mem::take(first).not() {
                     out!("\n");
                 }
-                self.emit_docs(ctx, docs, indent)?;
+                self.emit_docs(ctx, lang_config, docs, indent)?;
                 out!(
                     ("{};"),
                     ty.name_wrapping_var(self, name)
@@ -104,7 +104,7 @@ impl HeaderLanguage for Python {
     fn emit_opaque_type (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
-        lang_config: &'_ &LanguageConfig,
+        _lang_config: &'_ LanguageConfig,
         _docs: Docs<'_>,
         self_ty: &'_ dyn PhantomCType,
     ) -> io::Result<()>
@@ -120,7 +120,7 @@ impl HeaderLanguage for Python {
     fn emit_function (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
-        lang_config: &'_ &LanguageConfig,
+        _lang_config: &'_ LanguageConfig,
         _docs: Docs<'_>,
         fname: &'_ str,
         args: &'_ [FunctionArg<'_>],
@@ -162,7 +162,7 @@ impl HeaderLanguage for Python {
     fn emit_constant (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,
-        lang_config: &'_ &LanguageConfig,
+        _lang_config: &'_ LanguageConfig,
         _docs: Docs<'_>,
         name: &'_ str,
         _ty: &'_ dyn PhantomCType,

--- a/src/layout/_mod.rs
+++ b/src/layout/_mod.rs
@@ -6,6 +6,7 @@ use_prelude!();
 __cfg_headers__! {
     use crate::headers::{
         Definer,
+        LanguageConfig,
         languages::*,
     };
 }
@@ -54,17 +55,19 @@ trait CType
         fn define_self__impl (
             language: &'_ dyn HeaderLanguage,
             definer: &'_ mut dyn Definer,
+            lang_config: &'_ LanguageConfig,
         ) -> io::Result<()>
         ;
 
         fn define_self (
             language: &'_ dyn HeaderLanguage,
             definer: &'_ mut dyn Definer,
+            lang_config: &'_ LanguageConfig,
         ) -> io::Result<()>
         {
             definer.define_once(
                 &Self::name(language),
-                &mut |definer| Self::define_self__impl(language, definer),
+                &mut |definer| Self::define_self__impl(language, definer, lang_config),
             )
         }
 
@@ -110,6 +113,7 @@ impl<T : LegacyCType> CType for T {
         fn define_self__impl (
             _: &'_ dyn HeaderLanguage,
             _: &'_ mut dyn Definer,
+            _: &'_ LanguageConfig,
         ) -> io::Result<()>
         {
             unimplemented!()
@@ -118,18 +122,19 @@ impl<T : LegacyCType> CType for T {
         fn define_self (
             language: &'_ dyn HeaderLanguage,
             definer: &'_ mut dyn Definer,
+            lang_config: &'_ LanguageConfig,
         ) -> io::Result<()>
         {
             match () {
                 | _case if language.is::<C>() => {
-                    <Self as LegacyCType>::c_define_self(definer)
+                    <Self as LegacyCType>::c_define_self(definer, lang_config)
                 },
                 | _case if language.is::<CSharp>() => {
-                    <Self as LegacyCType>::csharp_define_self(definer)
+                    <Self as LegacyCType>::csharp_define_self(definer, lang_config)
                 },
                 #[cfg(feature = "python-headers")]
                 | _case if language.is::<Python>() => {
-                    <Self as LegacyCType>::c_define_self(definer)
+                    <Self as LegacyCType>::c_define_self(definer, lang_config)
                 },
                 | _ => unimplemented!(),
             }
@@ -137,7 +142,7 @@ impl<T : LegacyCType> CType for T {
 
         #[inline]
         fn name (
-            language: &'_ dyn HeaderLanguage,
+            language: &'_ dyn HeaderLanguage
         ) -> String
         {
             Self::name_wrapping_var(language, "")
@@ -398,20 +403,21 @@ unsafe trait LegacyCType
         ///     // ...
         /// }
         /// ```
-        fn c_define_self (definer: &'_ mut dyn Definer)
+        fn c_define_self (definer: &'_ mut dyn Definer, lang_config: &'_ LanguageConfig)
           -> io::Result<()>
         ;
         // {
-        //     Self::define_self(&C, definer)
+        //     Self::define_self(&C, definer, lang_config)
         // }
 
         // #[inline]
         // fn define_self__impl (
         //     language: &'_ dyn HeaderLanguage,
         //     definer: &'_ mut dyn Definer,
+        //     lang_config: &'_ LanguageConfig,
         // ) -> io::Result<()>
         // {
-        //     let _ = (language, definer);
+        //     let _ = (language, definer, lang_config);
         //     Ok(())
         // }
 
@@ -532,13 +538,14 @@ unsafe trait LegacyCType
 
         __cfg_csharp__! {
             /// Extra typedef code (_e.g._ `[LayoutKind.Sequential] struct ...`)
-            fn csharp_define_self (definer: &'_ mut dyn Definer)
+            fn csharp_define_self (definer: &'_ mut dyn Definer, lang_config: &'_ LanguageConfig)
               -> io::Result<()>
             ;
             // {
             //     Self::define_self(
             //         &CSharp,
             //         definer,
+            //         lang_config
             //     )
             // }
 

--- a/src/layout/impls.rs
+++ b/src/layout/impls.rs
@@ -112,14 +112,14 @@ const _: () = { macro_rules! impl_CTypes {
                 )
             }
 
-            fn c_define_self (definer: &'_ mut dyn Definer)
+            fn c_define_self (definer: &'_ mut dyn Definer, lang_config: &'_ LanguageConfig)
               -> io::Result<()>
             {
                 let ref me = Self::c_var("").to_string();
                 definer.define_once(
                     me,
                     &mut |definer| {
-                        Item::define_self(&crate::headers::languages::C, definer)?;
+                        Item::define_self(&crate::headers::languages::C, definer, lang_config)?;
                         writeln!(definer.out(),
                             concat!(
                                 "typedef struct {{\n",
@@ -150,11 +150,11 @@ const _: () = { macro_rules! impl_CTypes {
             }
 
             __cfg_csharp__! {
-                fn csharp_define_self (definer: &'_ mut dyn Definer)
+                fn csharp_define_self (definer: &'_ mut dyn Definer, lang_config: &'_ LanguageConfig)
                   -> io::Result<()>
                 {
                     let ref me = Self::csharp_ty();
-                    Item::define_self(&crate::headers::languages::CSharp, definer)?;
+                    Item::define_self(&crate::headers::languages::CSharp, definer, lang_config)?;
                     definer.define_once(me, &mut |definer| {
                         let array_items = {
                             // Poor man's specialization to use `fixed` arrays.
@@ -265,12 +265,12 @@ const _: () = { macro_rules! impl_CTypes {
                 fmt.write_str("_fptr")
             }
 
-            fn c_define_self (definer: &'_ mut dyn Definer)
+            fn c_define_self (definer: &'_ mut dyn Definer, lang_config: &'_ LanguageConfig)
               -> io::Result<()>
             {
-                Ret::define_self(&crate::headers::languages::C, definer)?; $(
-                $An::define_self(&crate::headers::languages::C, definer)?; $(
-                $Ai::define_self(&crate::headers::languages::C, definer)?; )*)?
+                Ret::define_self(&crate::headers::languages::C, definer, lang_config)?; $(
+                $An::define_self(&crate::headers::languages::C, definer, lang_config)?; $(
+                $Ai::define_self(&crate::headers::languages::C, definer, lang_config)?; )*)?
                 Ok(())
             }
 
@@ -292,12 +292,12 @@ const _: () = { macro_rules! impl_CTypes {
             }
 
             __cfg_csharp__! {
-                fn csharp_define_self (definer: &'_ mut dyn Definer)
+                fn csharp_define_self (definer: &'_ mut dyn Definer, lang_config: &'_ LanguageConfig)
                   -> io::Result<()>
                 {
-                    Ret::define_self(&crate::headers::languages::CSharp, definer)?; $(
-                    $An::define_self(&crate::headers::languages::CSharp, definer)?; $(
-                    $Ai::define_self(&crate::headers::languages::CSharp, definer)?; )*)?
+                    Ret::define_self(&crate::headers::languages::CSharp, definer, lang_config)?; $(
+                    $An::define_self(&crate::headers::languages::CSharp, definer, lang_config)?; $(
+                    $Ai::define_self(&crate::headers::languages::CSharp, definer, lang_config)?; )*)?
                     let ref me = Self::name(&crate::headers::languages::CSharp).to_string();
                     let ref mut _arg = {
                         let mut iter = (0 ..).map(|c| format!("_{}", c));
@@ -513,7 +513,7 @@ const _: () = { macro_rules! impl_CTypes {
                 fmt.write_str($CInt)
             }
 
-            fn c_define_self (definer: &'_ mut dyn Definer)
+            fn c_define_self (definer: &'_ mut dyn Definer, _lang_config: &'_ LanguageConfig)
               -> io::Result<()>
             {
                 definer.define_once(
@@ -544,6 +544,7 @@ const _: () = { macro_rules! impl_CTypes {
             __cfg_csharp__! {
                 fn csharp_define_self (
                     _: &'_ mut dyn crate::headers::Definer,
+                    _: &'_ crate::headers::LanguageConfig
                 ) -> io::Result<()>
                 {
                     Ok(())
@@ -589,6 +590,7 @@ const _: () = { macro_rules! impl_CTypes {
 
             fn c_define_self (
                 _: &'_ mut dyn crate::headers::Definer,
+                _: &'_ crate::headers::LanguageConfig,
             ) -> io::Result<()>
             {
                 Ok(())
@@ -597,6 +599,7 @@ const _: () = { macro_rules! impl_CTypes {
             __cfg_csharp__! {
                 fn csharp_define_self (
                     _: &'_ mut dyn crate::headers::Definer,
+                    _: &'_ crate::headers::LanguageConfig,
                 ) -> io::Result<()>
                 {
                     Ok(())
@@ -625,10 +628,10 @@ const _: () = { macro_rules! impl_CTypes {
                 write!(fmt, "{}_const_ptr", T::short_name())
             }
 
-            fn c_define_self (definer: &'_ mut dyn Definer)
+            fn c_define_self (definer: &'_ mut dyn Definer, lang_config: &'_ LanguageConfig)
               -> io::Result<()>
             {
-                T::define_self(&crate::headers::languages::C, definer)
+                T::define_self(&crate::headers::languages::C, definer, lang_config)
             }
 
             fn c_var_fmt (
@@ -645,10 +648,10 @@ const _: () = { macro_rules! impl_CTypes {
             }
 
             __cfg_csharp__! {
-                fn csharp_define_self (definer: &'_ mut dyn $crate::headers::Definer)
+                fn csharp_define_self (definer: &'_ mut dyn $crate::headers::Definer, lang_config: &'_ $crate::headers::LanguageConfig)
                   -> $crate::ඞ::io::Result<()>
                 {
-                    T::define_self(&crate::headers::languages::CSharp, definer)?;
+                    T::define_self(&crate::headers::languages::CSharp, definer, lang_config)?;
                     // definer.define_once("Const", &mut |definer| {
                     //     definer.out().write_all(concat!(
                     //         "[StructLayout(LayoutKind.Sequential)]\n",
@@ -692,10 +695,10 @@ const _: () = { macro_rules! impl_CTypes {
                 write!(fmt, "{}_ptr", T::short_name())
             }
 
-            fn c_define_self (definer: &'_ mut dyn Definer)
+            fn c_define_self (definer: &'_ mut dyn Definer, lang_config: &'_ LanguageConfig)
               -> io::Result<()>
             {
-                T::define_self(&crate::headers::languages::C, definer)
+                T::define_self(&crate::headers::languages::C, definer, lang_config)
             }
 
             fn c_var_fmt (
@@ -712,10 +715,10 @@ const _: () = { macro_rules! impl_CTypes {
             }
 
             __cfg_csharp__! {
-                fn csharp_define_self (definer: &'_ mut dyn $crate::headers::Definer)
+                fn csharp_define_self (definer: &'_ mut dyn $crate::headers::Definer, lang_config: &'_ LanguageConfig)
                   -> $crate::ඞ::io::Result<()>
                 {
-                    T::define_self(&crate::headers::languages::CSharp, definer)
+                    T::define_self(&crate::headers::languages::CSharp, definer, lang_config)
                 }
 
                 fn csharp_ty ()
@@ -862,7 +865,7 @@ unsafe
                 fmt.write_str("bool")
             }
 
-            fn c_define_self (definer: &'_ mut dyn Definer)
+            fn c_define_self (definer: &'_ mut dyn Definer, _lang_config: &'_ LanguageConfig)
               -> io::Result<()>
             {
                 definer.define_once(
@@ -890,6 +893,7 @@ unsafe
             __cfg_csharp__! {
                 fn csharp_define_self (
                     _: &'_ mut dyn crate::headers::Definer,
+                    _: &'_ crate::headers::LanguageConfig,
                 ) -> io::Result<()>
                 {
                     Ok(())
@@ -959,6 +963,7 @@ unsafe
 
             fn c_define_self (
                 _: &'_ mut dyn crate::headers::Definer,
+                _: &'_ crate::headers::LanguageConfig
             ) -> io::Result<()>
             {
                 Ok(())
@@ -967,6 +972,7 @@ unsafe
             __cfg_csharp__! {
                 fn csharp_define_self (
                     _: &'_ mut dyn crate::headers::Definer,
+                    _: &'_ crate::headers::LanguageConfig
                 ) -> io::Result<()>
                 {
                     Ok(())
@@ -1076,10 +1082,12 @@ impl<T> CType for OpaqueLayout<T> {
         fn define_self__impl (
             language: &'_ dyn HeaderLanguage,
             definer: &'_ mut dyn Definer,
+            lang_config: &'_ LanguageConfig,
         ) -> io::Result<()>
         {
             language.emit_opaque_type(
                 definer,
+                lang_config,
                 &[
                     &format!(
                         "The layout of `{}` is opaque/subject to changes.",

--- a/src/layout/macros.rs
+++ b/src/layout/macros.rs
@@ -45,7 +45,7 @@ macro_rules! export_cfgs {(
 // ```rust
 // __with_cfg_python__!(|$if_cfg_python| {
 //     match … {
-//         Language::C => …,
+//         LanguageConfig::C(_) => …,
 //         $($($if_cfg_python)?
 //             Language::Python => …,
 //         )?

--- a/src/proc_macro/derives/c_type/struct_.rs
+++ b/src/proc_macro/derives/c_type/struct_.rs
@@ -111,13 +111,15 @@ fn derive (
             fn define_self__impl (
                 language: &'_ dyn #headers::languages::HeaderLanguage,
                 definer: &'_ mut dyn #headers::Definer,
+                lang_config: &'_ #headers::LanguageConfig,
             ) -> #ඞ::io::Result<()>
             {
             #(
-                < #EachFieldTy as #CType >::define_self(language, definer)?;
+                < #EachFieldTy as #CType >::define_self(language, definer, lang_config)?;
             )*
                 language.emit_struct(
                     definer,
+                    lang_config,
                     &[#(#struct_docs),*],
                     &#ඞ::marker::PhantomData::<Self>,
                     &[#(#each_field),*],

--- a/src/proc_macro/derives/c_type/struct_.rs
+++ b/src/proc_macro/derives/c_type/struct_.rs
@@ -236,13 +236,15 @@ fn derive_transparent (
                 fn define_self__impl (
                     language: &'_ dyn #ඞ::HeaderLanguage,
                     definer: &'_ mut dyn #ඞ::Definer,
+                    lang_config: &'_ #ඞ::LanguageConfig
                 ) -> #ඞ::io::Result<()>
                 {
-                    <#CFieldTy as #ඞ::CType>::define_self(language, definer)?;
+                    <#CFieldTy as #ඞ::CType>::define_self(language, definer, lang_config)?;
 
                     if let #ඞ::Some(language) = language.supports_type_aliases() {
                         language.emit_type_alias(
                             definer,
+                            lang_config,
                             &[#(#docs),*],
                             &#ඞ::PhantomData::<Self>,
                             &#ඞ::PhantomData::<#CFieldTy>,
@@ -255,6 +257,7 @@ fn derive_transparent (
                 fn define_self (
                     language: &'_ dyn #ඞ::HeaderLanguage,
                     definer: &'_ mut dyn #ඞ::Definer,
+                    lang_config: &'_ #ඞ::LanguageConfig
                 ) -> #ඞ::io::Result<()>
                 {
                     // We need to be careful with the default idempotency guard:
@@ -269,7 +272,7 @@ fn derive_transparent (
                     };
                     definer.define_once(
                         &idempotency_definition_id,
-                        &mut |definer| Self::define_self__impl(language, definer),
+                        &mut |definer| Self::define_self__impl(language, definer, lang_config),
                     )
                 }
 

--- a/src/proc_macro/derives/repr_c/enum_.rs
+++ b/src/proc_macro/derives/repr_c/enum_.rs
@@ -126,6 +126,7 @@ fn derive (
                     HeaderLanguage,
                     EnumVariant,
                 },
+                LanguageConfig
             },
         };
 
@@ -169,11 +170,13 @@ fn derive (
             fn define_self__impl (
                 language: &'_ dyn #HeaderLanguage,
                 definer: &'_ mut dyn #Definer,
+                lang_config: &'_ #LanguageConfig,
             ) -> #ඞ::io::Result<()>
             {
-                <#Int as #CType>::define_self(language, definer)?;
+                <#Int as #CType>::define_self(language, definer, lang_config)?;
                 language.emit_simple_enum(
                     definer,
+                    lang_config,
                     &[#(#each_doc),*],
                     &#ඞ::marker::PhantomData::<Self>,
                     #mb_phantom_int,

--- a/src/proc_macro/derives/repr_c/struct_.rs
+++ b/src/proc_macro/derives/repr_c/struct_.rs
@@ -435,10 +435,12 @@ fn derive_opaque (
                 fn define_self__impl (
                     language: &'_ dyn #ඞ::HeaderLanguage,
                     definer: &'_ mut dyn #ඞ::Definer,
+                    lang_config: &'_ #ඞ::LanguageConfig,
                 ) -> #ඞ::io::Result<()>
                 {
                     language.emit_opaque_type(
                         definer,
+                        lang_config,
                         &[#(#docs),*],
                         &#ඞ::PhantomData::<Self>,
                     )

--- a/src/proc_macro/ffi_export/const_.rs
+++ b/src/proc_macro/ffi_export/const_.rs
@@ -96,7 +96,8 @@ fn handle (
 
                             <#ඞ::CLayoutOf<#Ty> as #ඞ::CType>::define_self(
                                 header_builder,
-                                definer
+                                definer,
+                                lang_config
                             )?;
 
                             header_builder

--- a/src/proc_macro/ffi_export/const_.rs
+++ b/src/proc_macro/ffi_export/const_.rs
@@ -33,7 +33,7 @@ fn handle (
                     name: #VAR_str,
                     gen_def: |
                         definer: &'_ mut dyn #ඞ::Definer,
-                        lang: #ඞ::Language,
+                        lang_config: &'_ #ඞ::LanguageConfig
                     | {
                         #krate::__with_cfg_python__!(|$if_cfg_python| {
                             use #krate::headers::{
@@ -42,11 +42,11 @@ fn handle (
                             };
 
                             let header_builder: &'static dyn HeaderLanguage = {
-                                match lang {
-                                    | Language::C => &languages::C,
-                                    | Language::CSharp => &languages::CSharp,
+                                match lang_config {
+                                    | Language::C(_) => &languages::C,
+                                    | Language::CSharp(_) => &languages::CSharp,
                                 $($($if_cfg_python)?
-                                    | Language::Python => &languages::Python,
+                                    | Language::Python(_) => &languages::Python,
                                 )?
                                 }
                             };
@@ -54,6 +54,7 @@ fn handle (
                             header_builder
                         }).emit_constant(
                             definer,
+                            lang_config,
                             &[ #(#each_doc),* ],
                             #VAR_str,
                             &#ඞ::PhantomData::<

--- a/src/proc_macro/ffi_export/const_.rs
+++ b/src/proc_macro/ffi_export/const_.rs
@@ -37,16 +37,16 @@ fn handle (
                     | {
                         #krate::__with_cfg_python__!(|$if_cfg_python| {
                             use #krate::headers::{
-                                Language,
+                                LanguageConfig,
                                 languages::{self, HeaderLanguage},
                             };
 
                             let header_builder: &'static dyn HeaderLanguage = {
                                 match lang_config {
-                                    | Language::C(_) => &languages::C,
-                                    | Language::CSharp(_) => &languages::CSharp,
+                                    | LanguageConfig::C(_) => &languages::C,
+                                    | LanguageConfig::CSharp(_) => &languages::CSharp,
                                 $($($if_cfg_python)?
-                                    | Language::Python(_) => &languages::Python,
+                                    | LanguageConfig::Python(_) => &languages::Python,
                                 )?
                                 }
                             };

--- a/src/proc_macro/ffi_export/fn_/mod.rs
+++ b/src/proc_macro/ffi_export/fn_/mod.rs
@@ -366,7 +366,7 @@ fn handle (
                     gen_def: {
                         fn gen_def #generics (
                             definer: &'_ mut dyn #ඞ::Definer,
-                            lang: #headers::Language,
+                            lang_config: &'_ #ඞ::LanguageConfig,
                         ) -> #ඞ::io::Result<()>
                         #where_clause
                         {#ඞ::io::Result::<()>::Ok({
@@ -385,12 +385,12 @@ fn handle (
                                 );
                             }
                         #(
-                            #headers::__define_self__::<#EachArgTy>(definer, lang)?;
+                            #headers::__define_self__::<#EachArgTy>(definer, lang_config)?;
                         )*
-                            #headers::__define_self__::<#RetTy>(definer, lang)?;
+                            #headers::__define_self__::<#RetTy>(definer, lang_config)?;
                             #headers::__define_fn__(
                                 definer,
-                                lang,
+                                lang_config,
                                 &[ #(#each_doc),* ],
                                 #export_name_str,
                                 &[

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -41,6 +41,7 @@ impl LegacyCType
 
     fn c_define_self (
         _: &'_ mut dyn crate::headers::Definer,
+        _: &'_ crate::headers::LanguageConfig
     ) -> io::Result<()>
     {
         Ok(())
@@ -49,6 +50,7 @@ impl LegacyCType
     __cfg_csharp__! {
         fn csharp_define_self (
             _: &'_ mut dyn crate::headers::Definer,
+            _: &'_ crate::headers::LanguageConfig
         ) -> io::Result<()>
         {
             Ok(())

--- a/tests/layout_macros.rs
+++ b/tests/layout_macros.rs
@@ -14,6 +14,7 @@ use ::std::{
 };
 use ::safer_ffi::{
     closure::*,
+    headers::languages::{CLanguageConfig, CSharpLanguageConfig},
     prelude::*,
     layout::{
         CType,
@@ -315,15 +316,15 @@ fn test_c_str_macro ()
 fn generate_headers ()
   -> ::std::io::Result<()>
 {Ok({
-    use ::safer_ffi::headers::Language::*;
-    for &language
-        in  &[
-                C,
-                CSharp,
+    use ::safer_ffi::headers::LanguageConfig::*;
+    for language
+        in  [
+                C(CLanguageConfig::default()),
+                CSharp(CSharpLanguageConfig::default()),
             ]
     {
         ::safer_ffi::headers::builder()
-            .with_language(language)
+            .with_language_config(language.clone())
             .to_writer(&mut ::std::io::stderr())
             .generate()?
     }


### PR DESCRIPTION
In order to allow easier customisation of generated header files on a per-language basis, I've expanded the `Language` enum to contain a per-language configuration (`CLanguageConfig`, `CSharpLanguageConfig`, etc.), which is then propagated to methods of `HeaderLanguage` implementers. Consequently I have renamed `Language` to `LanguageConfig` to better describe this new function.

The first config option I have added is based on my query in #202, which allows optional insertion of a custom macro text before each function definition. There's a good deal of other potential config options I'd like to add but holding off until I get approval on this approach for adding the `LanguageConfig` struct to contain and distributed this.