### PR TITLE
Add `serde` feature and implement `Serialize`/`Deserialize` for `Bytes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,7 @@ dependencies = [
  "safer-ffi",
  "safer_ffi-proc_macros",
  "scopeguard",
+ "serde",
  "stabby",
  "tokio",
  "uninit",
@@ -680,22 +681,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.156"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.156"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.58",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,13 @@ futures = [
     "dyn-traits",
 ]
 
-serde = ["dep:serde"]
+serde = [
+    "dep:serde",
+]
+
+stabby = [
+    "dep:stabby",
+]
 
 tokio = [
     "async-compat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,9 +66,7 @@ futures = [
     "dyn-traits",
 ]
 
-stabby = [
-    "dep:stabby",
-]
+serde = ["dep:serde"]
 
 tokio = [
     "async-compat",
@@ -143,6 +141,10 @@ paste.version = "1.0.12"
 
 scopeguard.version = "1.1.0"
 scopeguard.default-features = false
+
+serde.version = "1.0.204"
+serde.optional = true
+serde.default_features = false
 
 stabby.version = "36.1.1-rc8"
 stabby.optional = true

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -593,3 +593,17 @@ fn fuzz_stabby() {
         }
     }
 }
+
+#[cfg(feature = "serde")]
+impl<'a> serde::Serialize for Bytes<'a> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(self.as_slice())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'a, 'de: 'a> serde::Deserialize<'de> for Bytes<'a> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        serde::Deserialize::deserialize(deserializer).map(|x: &[u8]| Bytes::from(x))
+    }
+}


### PR DESCRIPTION
Enables efficient `serde` operations for `Byte` types. These can be enabled with the new `serde` feature flag