### PR TITLE
Add ability to emit type aliases to C headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.9"
+version = "0.1.10-rc1"
 dependencies = [
  "async-compat",
  "cratesio-placeholder-package",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.9"
+version = "0.1.10-rc1"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ path = "src/_lib.rs"
 
 [package]
 name = "safer-ffi"
-version = "0.1.9"  # Keep in sync
+version = "0.1.10-rc1"  # Keep in sync
 authors = [
     "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>",
 ]
@@ -179,7 +179,7 @@ version = "0.0.3"
 
 [dependencies.safer_ffi-proc_macros]
 path = "src/proc_macro"
-version = "=0.1.9"  # Keep in sync
+version = "=0.1.10-rc1"  # Keep in sync
 
 [workspace]
 members = [

--- a/ffi_tests/Cargo.lock
+++ b/ffi_tests/Cargo.lock
@@ -331,7 +331,7 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.9"
+version = "0.1.10-rc1"
 dependencies = [
  "futures",
  "inventory",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.9"
+version = "0.1.10-rc1"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/ffi_tests/generated.cffi
+++ b/ffi_tests/generated.cffi
@@ -115,6 +115,9 @@ int32_t const *
 max (
     slice_ref_int32_t xs);
 
+void *
+my_renamed_ptr_api (void);
+
 foo_t *
 new_foo (void);
 

--- a/ffi_tests/generated.cs
+++ b/ffi_tests/generated.cs
@@ -246,6 +246,11 @@ public unsafe partial class Ffi {
 
 public unsafe partial class Ffi {
     [DllImport(RustLib, ExactSpelling = true)] public static unsafe extern
+    void * my_renamed_ptr_api ();
+}
+
+public unsafe partial class Ffi {
+    [DllImport(RustLib, ExactSpelling = true)] public static unsafe extern
     foo_t * new_foo ();
 }
 

--- a/ffi_tests/generated.h
+++ b/ffi_tests/generated.h
@@ -230,6 +230,13 @@ max (
     slice_ref_int32_t xs);
 
 /** <No documentation available> */
+typedef void * my_renamed_ptr_t;
+
+/** <No documentation available> */
+my_renamed_ptr_t
+my_renamed_ptr_api (void);
+
+/** <No documentation available> */
 foo_t *
 new_foo (void);
 

--- a/ffi_tests/src/lib.rs
+++ b/ffi_tests/src/lib.rs
@@ -189,6 +189,21 @@ pub struct MyPtr {
     bar: (),
 }
 
+#[derive_ReprC(rename = "my_renamed_ptr")]
+#[repr(transparent)]
+pub struct MyRenamedPtr {
+    foo: ::core::ptr::NonNull<()>,
+    bar: (),
+}
+
+#[ffi_export]
+fn my_renamed_ptr_api() -> MyRenamedPtr {
+    MyRenamedPtr {
+        foo: ::core::ptr::NonNull::new(0xbad000 as _).unwrap(),
+        bar: ()
+    }
+}
+
 macro_rules! docs {() => (
     "Hello, `World`!"
 )}

--- a/ffi_tests/tests/c/main.c
+++ b/ffi_tests/tests/c/main.c
@@ -128,6 +128,8 @@ int main (
     });
     while (X > 0);
 
+    assert(my_renamed_ptr_api() == (void *)0xbad000);
+
     puts("C: [ok]");
 
     return EXIT_SUCCESS;

--- a/ffi_tests/tests/csharp/Tests.cs
+++ b/ffi_tests/tests/csharp/Tests.cs
@@ -132,6 +132,10 @@ static class Tests
             Trace.Assert(Ffi.returns_a_fn_ptr()(0x42) == 0x4200);
         }
 
+        unsafe {
+            Trace.Assert(Ffi.my_renamed_ptr_api() == (void *)0xbad000);
+        }
+
         Console.WriteLine("C#: [ok]");
     }
 }

--- a/js_tests/Cargo.lock
+++ b/js_tests/Cargo.lock
@@ -629,7 +629,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.9"
+version = "0.1.10-rc1"
 dependencies = [
  "cratesio-placeholder-package",
  "inventory",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.9"
+version = "0.1.10-rc1"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/js_tests/src/lib.rs
+++ b/js_tests/src/lib.rs
@@ -359,3 +359,18 @@ fn sleep (ms: u32)
         let _ = wasm_bindgen_futures::JsFuture::from(sleep(ms)).await;
     }
 }
+
+#[derive_ReprC(js, rename = "my_renamed_ptr")]
+#[repr(transparent)]
+pub struct MyRenamedPtr {
+    pub foo: ::core::ptr::NonNull<()>,
+    pub bar: (),
+}
+
+#[ffi_export(js)]
+fn my_renamed_ptr_api() -> MyRenamedPtr {
+    MyRenamedPtr {
+        foo: ::core::ptr::NonNull::new(0xbad000 as _).unwrap(),
+        bar: (),
+    }
+}

--- a/js_tests/tests/tests.mjs
+++ b/js_tests/tests/tests.mjs
@@ -284,29 +284,31 @@ export async function run_tests({ ffi, performance, assert, is_web }) {
         )
     }
 
-  if (!is_web) {
-    assert.equal(ffi.getDeadlockTimeout(), 5000);
+    if (!is_web) {
+      assert.equal(ffi.getDeadlockTimeout(), 5000);
 
-    let error;
-    try {
-      ffi.setDeadlockTimeout("huehuehue");
-    } catch (e) {
-      error = e;
+      let error;
+      try {
+        ffi.setDeadlockTimeout("huehuehue");
+      } catch (e) {
+        error = e;
+      }
+      assert.equal(error?.message, "Expected a positive number");
+
+      ffi.setDeadlockTimeout(500);
+
+      assert.equal(ffi.getDeadlockTimeout(), 500);
+
+      error = null;
+      try {
+        ffi.setDeadlockTimeout(0);
+      } catch (e) {
+        error = e;
+      }
+      assert.equal(error?.message, "Deadlock timeout can only be set once");
     }
-    assert.equal(error?.message, "Expected a positive number");
 
-    ffi.setDeadlockTimeout(500);
-
-    assert.equal(ffi.getDeadlockTimeout(), 500);
-
-    error = null;
-    try {
-      ffi.setDeadlockTimeout(0);
-    } catch (e) {
-      error = e;
-    }
-    assert.equal(error?.message, "Deadlock timeout can only be set once");
-  }
+    assert.equal(ffi.my_renamed_ptr_api().addr, 0xbad000);
 
     console.log('Js tests passed successfully ✅');
 }

--- a/src/headers/_mod.rs
+++ b/src/headers/_mod.rs
@@ -117,8 +117,6 @@ mod languages;
 pub use definer::{Definer, HashSetDefiner};
 mod definer;
 
-
-
 match_! {(
     /// Sets up the name of the `ifndef` guard of the header file.
     ///

--- a/src/headers/languages/c.rs
+++ b/src/headers/languages/c.rs
@@ -30,6 +30,35 @@ impl HeaderLanguage for C {
         Ok(())
     }
 
+    fn supports_type_aliases(self: &'_ C)
+      -> Option<&'_ dyn HeaderLanguageSupportingTypeAliases>
+    {
+        return Some(self);
+        // where
+        impl HeaderLanguageSupportingTypeAliases for C {
+            fn emit_type_alias(
+                self: &'_ Self,
+                ctx: &'_ mut dyn Definer,
+                docs: Docs<'_>,
+                self_ty: &'_ dyn PhantomCType,
+                inner_ty: &'_ dyn PhantomCType,
+            ) -> io::Result<()>
+            {
+                let ref indent = Indentation::new(4 /* ctx.indent_width() */);
+                mk_out!(indent, ctx.out());
+                self.emit_docs(ctx, docs, indent)?;
+                let ref aliaser = self_ty.name(self);
+                let ref aliasee = inner_ty.name(self);
+                out!((
+                    "typedef {aliasee} {aliaser};"
+                ));
+
+                out!("\n");
+                Ok(())
+            }
+        }
+    }
+
     fn emit_simple_enum (
         self: &'_ Self,
         ctx: &'_ mut dyn Definer,

--- a/src/headers/languages/mod.rs
+++ b/src/headers/languages/mod.rs
@@ -64,8 +64,14 @@ type Docs<'lt> = &'lt [&'lt str];
 
 pub
 trait HeaderLanguage : UpcastAny {
-    fn language_name(&self) -> &'static str {
+    fn language_name(self: &'_ Self) -> &'static str {
         ::core::any::type_name::<Self>()
+    }
+
+    fn supports_type_aliases(self: &'_ Self)
+      -> Option<&'_ dyn HeaderLanguageSupportingTypeAliases>
+    {
+        None
     }
 
     fn emit_simple_enum (
@@ -126,6 +132,18 @@ trait HeaderLanguage : UpcastAny {
         // it is not directly called by the framework.
         Ok(())
     }
+}
+
+pub
+trait HeaderLanguageSupportingTypeAliases : HeaderLanguage {
+    fn emit_type_alias(
+        self: &'_ Self,
+        ctx: &'_ mut dyn Definer,
+        docs: Docs<'_>,
+        self_ty: &'_ dyn PhantomCType,
+        inner_ty: &'_ dyn PhantomCType,
+    ) -> io::Result<()>
+    ;
 }
 
 pub

--- a/src/proc_macro/Cargo.toml
+++ b/src/proc_macro/Cargo.toml
@@ -4,7 +4,7 @@ proc-macro = true
 
 [package]
 name = "safer_ffi-proc_macros"
-version = "0.1.9"  # Keep in sync
+version = "0.1.10-rc1"  # Keep in sync
 authors = ["Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com>"]
 edition = "2021"
 

--- a/src/proc_macro/derives/c_type/struct_.rs
+++ b/src/proc_macro/derives/c_type/struct_.rs
@@ -12,8 +12,25 @@ fn derive (
     fields: &'_ Fields,
 ) -> Result<TokenStream2>
 {
-    if matches!(fields, Fields::Unnamed { .. } | Fields::Unit { .. }) {
-        bail!("only braced structs are supported");
+    if let Some(repr) = attrs.iter().find_map(|attr| {
+        bool::then(
+            attr.path.is_ident("repr"),
+            || attr.parse_args::<Ident>().ok()
+        ).flatten()
+    })
+    {
+        if repr.to_string() == "transparent" {
+            return derive_transparent(
+                args,
+                attrs,
+                pub_,
+                StructName,
+                generics,
+                fields,
+            );
+        }
+    } else {
+        bail!("Missing `#[repr]`!");
     }
 
     #[apply(let_quote!)]
@@ -29,6 +46,10 @@ fn derive (
     };
 
     let mut ret = quote!();
+
+    if matches!(fields, Fields::Unnamed { .. } | Fields::Unit { .. }) {
+        bail!("only braced structs are supported");
+    }
 
     if cfg!(feature = "js") && args.js.is_some() {
         // invoke the legacy `CType!` macro which is the one currently featuring
@@ -127,32 +148,11 @@ fn derive (
     }
 
     ret.extend({
-        let (intro_generics, fwd_generics, where_clauses) =
-            generics.split_for_impl()
-        ;
+        let (intro_generics, fwd_generics, where_clauses) = &generics.split_for_impl();
+
+        let trivial_impls = trivial_impls(intro_generics, fwd_generics, where_clauses, StructName);
 
         quote!(
-            impl #intro_generics
-                #ඞ::Clone
-            for
-                #StructName #fwd_generics
-            #where_clauses
-            {
-                #[inline]
-                fn clone (self: &'_ Self)
-                  -> Self
-                {
-                    *self
-                }
-            }
-
-            impl #intro_generics
-                #ඞ::Copy
-            for
-                #StructName #fwd_generics
-            #where_clauses
-            {}
-
             unsafe
             impl #intro_generics
                 #CType
@@ -163,24 +163,7 @@ fn derive (
                 #impl_body
             }
 
-            // If it is CType, it trivially is ReprC.
-            unsafe
-            impl #intro_generics
-                #ReprC
-            for
-                #StructName #fwd_generics
-            #where_clauses
-            {
-                type CLayout = Self;
-
-                #[inline]
-                fn is_valid (
-                    _: &'_ Self::CLayout,
-                ) -> #ඞ::bool
-                {
-                    true
-                }
-            }
+            #trivial_impls
         )
     });
 
@@ -189,4 +172,182 @@ fn derive (
     // }
 
     Ok(ret)
+}
+
+pub(in crate)
+fn derive_transparent (
+    args: Args,
+    attrs: &'_ [Attribute],
+    _pub: &'_ Visibility,
+    StructName_Layout @ _: &'_ Ident,
+    generics: &'_ Generics,
+    fields: &'_ Fields,
+) -> Result<TokenStream2>
+{
+    // Example input:
+    #[cfg(any())]
+    #[derive_CType(js, rename = "dittoffi_string")]
+    #[repr(transparent)]
+    struct FfiString_Layout(
+        CLayoutOf<char_p::Box>,
+    )
+    where
+        char_p::Box : ReprC,
+    ;
+
+    #[apply(let_quote)]
+    use ::safer_ffi::ඞ;
+
+    let mut ret = quote!();
+
+    let Args { rename, .. } = &args;
+
+    let docs = utils::extract_docs(attrs)?;
+
+    let CFieldTy @ _ = match fields.iter().next() {
+        | Some(f) => &f.ty,
+        | None => bail! {
+            "`#[repr(transparent)]` requires at least one field" => fields,
+        },
+    };
+
+    let (intro_generics, fwd_generics, where_clauses) = &generics.split_for_impl();
+
+    ret.extend(quote!(
+        unsafe
+        impl #intro_generics
+            #ඞ::CType
+        for
+            #StructName_Layout #fwd_generics
+        #where_clauses
+        {
+            type OPAQUE_KIND = <#CFieldTy as #ඞ::CType>::OPAQUE_KIND;
+
+            ::safer_ffi::__cfg_headers__! {
+                fn short_name ()
+                  -> #ඞ::String
+                {
+                    #ඞ::String::from(#rename)
+                }
+
+                #[allow(nonstandard_style)]
+                fn define_self__impl (
+                    language: &'_ dyn #ඞ::HeaderLanguage,
+                    definer: &'_ mut dyn #ඞ::Definer,
+                ) -> #ඞ::io::Result<()>
+                {
+                    <#CFieldTy as #ඞ::CType>::define_self(language, definer)?;
+                    if let #ඞ::Some(language) = language.supports_type_aliases() {
+                        language.emit_type_alias(
+                            definer,
+                            &[#(#docs),*],
+                            &#ඞ::PhantomData::<Self>,
+                            &#ඞ::PhantomData::<#CFieldTy>,
+                        )?;
+                    }
+
+                    Ok(())
+                }
+
+                fn name (
+                    language: &'_ dyn #ඞ::HeaderLanguage,
+                ) -> String
+                {
+                    if let #ඞ::Some(language) = language.supports_type_aliases() {
+                        #ඞ::std::format!("{}_t", Self::short_name())
+                    } else {
+                        <#CFieldTy as #ඞ::CType>::name(language)
+                    }
+                }
+            }
+        }
+    ));
+
+    ret.extend(trivial_impls(intro_generics, fwd_generics, where_clauses, StructName_Layout));
+
+    if cfg!(feature = "js") && args.js.is_some() {
+        #[apply(let_quote)]
+        use ::safer_ffi::js;
+
+        ret.extend(quote!(
+            impl #intro_generics
+                #js::ReprNapi
+            for
+                #StructName_Layout #fwd_generics
+            #where_clauses
+            {
+                type NapiValue = <#CFieldTy as #js::ReprNapi>::NapiValue;
+
+                fn to_napi_value (
+                    self: Self,
+                    env: &'_ #js::Env,
+                ) -> #js::Result< Self::NapiValue >
+                {
+                    <#CFieldTy as #js::ReprNapi>::to_napi_value(self.0, env)
+                }
+
+                fn from_napi_value (
+                    env: &'_ #js::Env,
+                    napi_value: Self::NapiValue,
+                ) -> #js::Result<Self>
+                {
+                    <#CFieldTy as #js::ReprNapi>::from_napi_value(env, napi_value).map(Self)
+                }
+            }
+        ));
+    }
+
+    Ok(ret)
+}
+
+fn trivial_impls(
+    intro_generics: &dyn ToTokens,
+    fwd_generics: &dyn ToTokens,
+    where_clauses: &dyn ToTokens,
+    StructName @ _: &dyn ToTokens,
+) -> TokenStream2 {
+    #[apply(let_quote)]
+    use ::safer_ffi::ඞ;
+
+    quote!(
+        impl #intro_generics
+            #ඞ::Clone
+        for
+            #StructName #fwd_generics
+        #where_clauses
+        {
+            #[inline]
+            fn clone (self: &'_ Self)
+              -> Self
+            {
+                *self
+            }
+        }
+
+        impl #intro_generics
+            #ඞ::Copy
+        for
+            #StructName #fwd_generics
+        #where_clauses
+        {}
+
+        // If it is CType, it trivially is ReprC.
+        unsafe
+        impl #intro_generics
+            #ඞ::ReprC
+        for
+            #StructName #fwd_generics
+        #where_clauses
+        {
+            type CLayout = Self;
+
+            #[inline]
+            fn is_valid (
+                _: &'_ Self::CLayout,
+            ) -> #ඞ::bool
+            {
+                true
+            }
+        }
+    )
 }


### PR DESCRIPTION
In order to be able to produce more readable C headers, this PR adds the ability to emit the so-called "type aliases", _i.e._, `typedef`s, using `safer-ffi`.

The syntax chosen for it is as follows:

 1. Start off a `#[repr(transparent)]` Rust newtype wrapper struct;
 1. Slap a `rename = "…"` argument on the `#[derive_ReprC()]` macro attribute.

```rs
#[derive_ReprC(rename = "ffi_string")]
#[repr(transparent)]
pub
struct FfiString {
    field_name_only_visible_in_rust: char_p::Box,
}
```

to yield, in C:

```c
typedef char * ffi_string_t;
```

C#, for the moment, "ignores the `rename`", thence acting as an invisible wrapper on the FFI side, since its support for aliases, the `using` directives, are for some very silly reason constrained to be at the beginning of the file.

  - C# failed attempt:

    ```csharp
    using ffi_string_t = char *; // Error, not at the top of the file!
    ```

Since `safer-ffi`'s header generation architecture revolves around a "chronological"/dependency-based ordering of the types, support for aliases there appears to be more trouble than it is worth, and has currently been discarded.