### PR TITLE
Add interning to `Bytes`, reducing the need for allocations when slices are small.

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -116,6 +116,9 @@ impl<'a> Bytes<'a> {
     /// let data = "Hello there, this string is long enough that it'll cross the inline-threshold (core::mem::size_of::<Bytes>() - 1) on all supported platforms";
     /// let mut bytes = Bytes::from_slice(data.as_bytes());
     /// assert!(bytes.upgrade_will_allocate());
+    /// let data = "This string isn't";
+    /// let mut bytes = Bytes::from_slice(data.as_bytes());
+    /// assert!(!bytes.upgrade_will_allocate());
     /// ```
     ///
     /// Note that if the slice is small enough to be interned in the [`Bytes`], it'll be, allowing for free upgrades. You may use the [`Bytes::intern_slice`] constructor instead of this one if you want to be able to handle interning not being possible.

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -552,7 +552,7 @@ unsafe extern "C" fn retain_stabby_arc_bytes(this: *const (), capacity: usize) {
         })
     };
     // we don't own any `Arc` in this function:
-    let this = &*::mem::ManuallyDrop::new(this);
+    let this = &*mem::ManuallyDrop::new(this);
     // time to do the increment:
     mem::forget(this.clone());
 }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -93,7 +93,7 @@ impl<'a> Bytes<'a> {
         if self.is_inlined() {
             None
         } else {
-            // SAFETY: If the value is not
+            // SAFETY: If the value is not inlined, then we know the vtable to have been initialized to a valid reference.
             unsafe { mem::transmute::<ptr::NonNull<BytesVt>, Option<&'a BytesVt>>(self.vtable) }
         }
     }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -3,6 +3,7 @@ use core::{
     fmt::Debug,
     hash::Hash,
     ops::{Deref, RangeBounds},
+    ptr::NonNull,
 };
 
 #[cfg(feature = "alloc")]
@@ -11,7 +12,11 @@ use safer_ffi_proc_macros::derive_ReprC;
 
 /// A slice of bytes optimized for sharing ownership of it and its subslices.
 ///
-/// Typically, [`Bytes`] can constructed from `&[u8]`, `Arc<[u8]>` or `Arc<T: AsRef<[u8]>>`.
+/// Typically, [`Bytes`] can constructed from `&'static [u8]`, `Arc<[u8]>` or `Arc<T: AsRef<[u8]>>`.
+///
+/// [`Bytes`] can also "intern" small enough slices: that is, if the slice is more than one byte smaller than
+/// [`Bytes`] memory layout (which is 40 bytes on 64bit architectures), it may be store directly in that memory
+/// instead of through indirection.
 #[derive_ReprC]
 #[repr(C)]
 #[cfg_attr(feature = "stabby", stabby::stabby)]
@@ -20,7 +25,8 @@ pub struct Bytes<'a> {
     len: usize,
     data: *const (),
     capacity: usize,
-    vtable: &'a BytesVt,
+    vtable: NonNull<BytesVt>,
+    marker: core::marker::PhantomData<&'a [u8]>,
 }
 #[cfg(not(feature = "stabby"))]
 unsafe impl<'a> crate::layout::__HasNiche__ for Bytes<'a> {
@@ -51,6 +57,7 @@ const _: () = {
 };
 
 extern "C" fn noop(_: *const (), _: usize) {}
+
 impl<'a> Bytes<'a> {
     /// Constructs an empty slice.
     ///
@@ -58,9 +65,32 @@ impl<'a> Bytes<'a> {
     pub const fn empty() -> Self {
         Self::from_static([].as_slice())
     }
+    const fn is_interned(&self) -> bool {
+        (unsafe {
+            (self as *const Self)
+                .cast::<u8>()
+                .add(core::mem::size_of::<Self>() - 1)
+                .read()
+        } & 1)
+            != 0
+    }
+    fn vtable(&self) -> Option<&'a BytesVt> {
+        if self.is_interned() {
+            None
+        } else {
+            unsafe { Some(self.vtable.as_ref()) }
+        }
+    }
+
     /// Constructs a [`Bytes`] referring to static data.
     ///
-    /// This is preferable to `<Bytes as From<&'static [u8]>>::from` in the sense that even if the value is cast to a non-static lifetime, [`Self::upgrade`] won't need to reallocate to recover the `'static` lifetime.
+    /// This is equivalent to `<Bytes as From<&'static [u8]>>::from`, guaranteeing that [`Self::upgrade`] won't need to reallocate to recover the `'static` lifetime through [`Bytes::upgrade`].
+    /// ```
+    /// # use safer_ffi::bytes::Bytes;
+    /// let data = "Hello there, this string is long enough that it'll cross the inline-threshold (core::mem::size_of::<Bytes>() - 1) on all supported platforms";
+    /// let mut bytes = Bytes::from_static(data.as_bytes());
+    /// assert!(!bytes.upgrade_will_allocate());
+    /// ```
     pub const fn from_static(data: &'static [u8]) -> Self {
         const VT: BytesVt = BytesVt {
             retain: Some(noop),
@@ -71,14 +101,70 @@ impl<'a> Bytes<'a> {
             len: data.len(),
             data: data.as_ptr().cast(),
             capacity: data.len(),
-            vtable: &VT,
+            vtable: unsafe {
+                NonNull::new_unchecked(&VT as &'static BytesVt as *const BytesVt as *mut BytesVt)
+            },
+            marker: core::marker::PhantomData,
         }
     }
+
+    /// Constructs a [`Bytes`] referring to a slice.
+    ///
+    /// Unlike [`Bytes::from_static`] and `<Bytes as From<&'static ..>>::from` implementations, the resulting [`Bytes`] cannot tell that it's referring to `'static` data even if it is, and will therefore perform a copy when [`Bytes::upgrade`]ing.
+    /// ```
+    /// # use safer_ffi::bytes::Bytes;
+    /// let data = "Hello there, this string is long enough that it'll cross the inline-threshold (core::mem::size_of::<Bytes>() - 1) on all supported platforms";
+    /// let mut bytes = Bytes::from_slice(data.as_bytes());
+    /// assert!(bytes.upgrade_will_allocate());
+    /// ```
+    ///
+    /// Note that if the slice is small enough to be interned in the [`Bytes`], it'll be, allowing for free upgrades. You may use the [`Bytes::intern_slice`] constructor instead of this one if you want to be able to handle interning not being possible.
+    pub fn from_slice(data: &'a [u8]) -> Self {
+        static VT: BytesVt = BytesVt {
+            release: None,
+            retain: Some(noop),
+        };
+        Self::intern_slice(data).unwrap_or_else(|| Self {
+            start: data.as_ptr().cast(),
+            len: data.len(),
+            data: data.as_ptr().cast(),
+            capacity: data.len(),
+            vtable: unsafe {
+                NonNull::new_unchecked(&VT as &'static BytesVt as *const BytesVt as *mut BytesVt)
+            },
+            marker: core::marker::PhantomData,
+        })
+    }
+
+    /// Constructs a [`Bytes`] from a short slice by interning it, untying [`Bytes`]'s lifetime from `slice`'s.
+    ///
+    /// If the slice is too long to be interned, this constructor returns `None` instead.
+    ///
+    /// A slice may be interned if it is at least one byte smaller than [`Bytes`], which has the same size as `[usize; 5]`.
+    ///
+    /// ```
+    /// # use safer_ffi::bytes::Bytes;
+    /// let interned = Bytes::intern_slice("Hi".as_bytes()).unwrap();
+    /// assert_eq!(interned.as_slice(), "Hi".as_bytes());
+    /// assert!(!interned.clone_will_allocate());
+    /// assert!(!interned.upgrade_will_allocate());
+    /// assert!(Bytes::intern_slice("This slice is too long to intern, even on architectures with 128 bit pointer-size.".as_bytes()).is_none())
+    /// ```
+    pub fn intern_slice(slice: &[u8]) -> Option<Bytes<'static>> {
+        let mut buffer = [0; core::mem::size_of::<Self>()];
+        if slice.len() >= buffer.len() {
+            return None;
+        }
+        buffer[..slice.len()].copy_from_slice(slice);
+        buffer[buffer.len() - 1] = 1 | ((slice.len() as u8) << 1);
+        unsafe { core::mem::transmute(buffer) }
+    }
+
     /// Slices `self` in-place:
     /// ```
     /// # use safer_ffi::bytes::Bytes;
-    /// let data = b"Hello there".as_slice();
-    /// let mut bytes = Bytes::from_static(data);
+    /// let data = b"Hello there";
+    /// let mut bytes = Bytes::from(data);
     /// bytes.shrink_to(3..7);
     /// assert_eq!(&data[3..7], bytes.as_slice());
     /// ```
@@ -93,14 +179,19 @@ impl<'a> Bytes<'a> {
         let end = match range.end_bound() {
             core::ops::Bound::Included(i) => *i + 1,
             core::ops::Bound::Excluded(i) => *i,
-            core::ops::Bound::Unbounded => self.len,
+            core::ops::Bound::Unbounded => self.len(),
         };
         assert!(start <= end);
         assert!(end <= self.len);
         let len = end - start;
-        self.start = unsafe { self.start.add(start) };
-        self.len = len;
+        if len < core::mem::size_of::<Self>() {
+            *self = Self::intern_slice(&self[start..end]).unwrap()
+        } else {
+            self.start = unsafe { self.start.add(start) };
+            self.len = len;
+        }
     }
+
     /// Convenience around [`Self::shrink_to`] for better method chaining.
     /// ```
     /// # use safer_ffi::bytes::Bytes;
@@ -114,6 +205,7 @@ impl<'a> Bytes<'a> {
         self.shrink_to(range);
         self
     }
+
     #[cfg(feature = "alloc")]
     /// Splits the slice at `index`.
     /// ```
@@ -130,23 +222,52 @@ impl<'a> Bytes<'a> {
     /// # Errors
     /// Returns `self` if `index` is out of bounds.
     pub fn split_at(self, index: usize) -> Result<(Self, Self), Self> {
-        if index <= self.len {
-            let mut left = self.clone();
-            let mut right = left.clone();
-            left.len = index;
-            right.len -= index;
-            right.start = unsafe { right.start.add(index) };
-            Ok((left, right))
+        if index <= self.len() {
+            if index < core::mem::size_of::<Self>() {
+                let left = Self::intern_slice(&self[..index]).unwrap();
+                Ok((left, self.subsliced(index..)))
+            } else {
+                if self.len() - index < core::mem::size_of::<Self>() {
+                    let right = Self::intern_slice(&self[index..]).unwrap();
+                    Ok((self.subsliced(..index), right))
+                } else {
+                    let mut left = self.clone();
+                    let mut right = left.clone();
+                    left.len = index;
+                    right.len -= index;
+                    right.start = unsafe { right.start.add(index) };
+                    Ok((left, right))
+                }
+            }
         } else {
             Err(self)
         }
     }
+
+    /// Returns the length of the slice.
+    pub const fn len(&self) -> usize {
+        if self.is_interned() {
+            (unsafe { core::mem::transmute::<_, [u8; core::mem::size_of::<usize>()]>(self.vtable) }
+                [core::mem::size_of::<usize>() - 1] as usize)
+                >> 1
+        } else {
+            self.len
+        }
+    }
+
     /// Returns the slice's contents.
     pub const fn as_slice(&self) -> &[u8] {
-        unsafe { core::slice::from_raw_parts(self.start, self.len) }
+        if self.is_interned() {
+            unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, self.len()) }
+        } else {
+            unsafe { core::slice::from_raw_parts(self.start, self.len) }
+        }
     }
+
     #[cfg(any(feature = "alloc", feature = "stabby"))]
     /// Copies the slice into an `stabby::sync::ArcSlice<u8>` if `stabby` is enabled or a `Arc<[u8]>` otherwise before wrapping it in [`Bytes`].
+    ///
+    /// If the slice is small enough to do so, it will be [interned](Bytes::intern_slice) instead, saving the need to allocate.
     pub fn copied_from_slice(slice: &[u8]) -> Bytes<'static> {
         match_cfg! {
             feature = "stabby" => {
@@ -156,31 +277,38 @@ impl<'a> Bytes<'a> {
                 type ArcSlice<T> = Arc<[T]>;
             },
         }
-        ArcSlice::<u8>::from(slice).into()
+        Self::intern_slice(slice).unwrap_or_else(|| ArcSlice::<u8>::from(slice).into())
     }
+
     #[cfg(any(feature = "alloc", feature = "stabby"))]
     /// Proves that the slice can be held onto for arbitrary durations, or copies it into a new `Arc<[u8]>` that does.
     ///
     /// Note that `feature = "stabby"` being enabled will cause a `stabby::sync::ArcSlice<u8>` to be used instead of `Arc<[u8]>`.
     pub fn upgrade(self: Bytes<'a>) -> Bytes<'static> {
-        if !self.vtable.is_borrowed() {
+        if self.vtable().map_or(true, |vt| !vt.is_borrowed()) {
             return unsafe { core::mem::transmute(self) };
         }
         Self::copied_from_slice(&self)
     }
+
     /// Attempts to prove that the slice has a static lifetime.
     /// # Errors
     /// Returns the original instance if it couldn't be proven to be `'static`.
     pub fn noalloc_upgrade(self: Bytes<'a>) -> Result<Bytes<'static>, Self> {
-        if !self.vtable.is_borrowed() {
+        if !self.vtable().map_or(true, |vt| !vt.is_borrowed()) {
             Ok(unsafe { core::mem::transmute(self) })
         } else {
-            Err(self)
+            Self::intern_slice(&self).ok_or(self)
         }
     }
+
     /// Only calls [`Clone::clone`] if no reallocation would be necessary for it, returning `None` if it would have been.
     pub fn noalloc_clone(&self) -> Option<Self> {
-        let retain = self.vtable.retain?;
+        let Some(vtable) = self.vtable() else {
+            // SAFETY: `Bytes` is `Copy` if it is interned.
+            return Some(unsafe { core::ptr::read(self) });
+        };
+        let retain = vtable.retain?;
         unsafe { retain(self.data, self.capacity) };
         Some(Self {
             start: self.start,
@@ -188,17 +316,27 @@ impl<'a> Bytes<'a> {
             data: self.data,
             capacity: self.capacity,
             vtable: self.vtable,
+            marker: core::marker::PhantomData,
         })
     }
+
     /// Returns `true` if a call to [`Self::upgrade`] would cause an allocation.
-    pub const fn upgrade_will_allocate(&self) -> bool {
-        self.vtable.is_borrowed()
+    pub fn upgrade_will_allocate(&self) -> bool {
+        match self.vtable() {
+            Some(t) => t.is_borrowed() && self.len() >= core::mem::size_of::<Self>(),
+            None => false,
+        }
     }
+
     /// Returns `true` if a call to [`Clone::clone`] would cause an allocation.
-    pub const fn clone_will_allocate(&self) -> bool {
-        self.vtable.retain.is_none()
+    pub fn clone_will_allocate(&self) -> bool {
+        match self.vtable() {
+            Some(t) => t.retain.is_none() && self.len() >= core::mem::size_of::<Self>(),
+            None => false,
+        }
     }
 }
+
 impl Default for Bytes<'_> {
     fn default() -> Self {
         Bytes::empty()
@@ -222,11 +360,15 @@ impl Borrow<[u8]> for Bytes<'_> {
 }
 impl Debug for Bytes<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Bytes")
-            .field("data", &self.as_slice())
-            .field("owned", &!self.upgrade_will_allocate())
-            .field("shared", &!self.clone_will_allocate())
-            .finish()
+        if f.alternate() {
+            f.debug_struct("Bytes")
+                .field("data", &self.as_slice())
+                .field("owned", &!self.upgrade_will_allocate())
+                .field("shared", &!self.clone_will_allocate())
+                .finish()
+        } else {
+            Debug::fmt(self.as_slice(), f)
+        }
     }
 }
 impl Hash for Bytes<'_> {
@@ -250,19 +392,30 @@ impl Ord for Bytes<'_> {
         self.as_slice().cmp(other)
     }
 }
-impl<'a> From<&'a [u8]> for Bytes<'a> {
-    fn from(data: &'a [u8]) -> Self {
-        static VT: BytesVt = BytesVt {
-            release: None,
-            retain: Some(noop),
-        };
-        Bytes {
-            start: data.as_ptr().cast(),
-            len: data.len(),
-            data: data.as_ptr().cast(),
-            capacity: data.len(),
-            vtable: &VT,
-        }
+
+#[cfg(feature = "std")]
+impl std::io::Read for Bytes<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let len = self.len().min(buf.len());
+        buf[..len].copy_from_slice(&self[..len]);
+        self.shrink_to(len..);
+        Ok(len)
+    }
+}
+
+impl<'a> From<&'static [u8]> for Bytes<'a> {
+    fn from(data: &'static [u8]) -> Self {
+        Self::from_static(data)
+    }
+}
+impl<'a, const N: usize> From<&'static [u8; N]> for Bytes<'a> {
+    fn from(data: &'static [u8; N]) -> Self {
+        Self::from_static(data.as_slice())
+    }
+}
+impl<'a> From<&'static str> for Bytes<'a> {
+    fn from(data: &'static str) -> Self {
+        Self::from_static(data.as_bytes())
     }
 }
 #[cfg(feature = "alloc")]
@@ -287,7 +440,12 @@ impl From<Arc<[u8]>> for Bytes<'static> {
             len: data.len(),
             data: Arc::into_raw(data) as *const (),
             capacity,
-            vtable: &ARC_BYTES_VT,
+            vtable: unsafe {
+                NonNull::new_unchecked(
+                    &ARC_BYTES_VT as &'static BytesVt as *const BytesVt as *mut BytesVt,
+                )
+            },
+            marker: core::marker::PhantomData,
         }
     }
 }
@@ -306,10 +464,14 @@ impl<'a, T: Sized + AsRef<[u8]> + Send + Sync + 'a> From<Arc<T>> for Bytes<'a> {
             len: data.len(),
             capacity: data.len(),
             data: Arc::into_raw(value) as *const (),
-            vtable: &BytesVt {
-                release: Some(release::<T>),
-                retain: Some(retain::<T>),
+            vtable: unsafe {
+                NonNull::new_unchecked(&BytesVt {
+                    release: Some(release::<T>),
+                    retain: Some(retain::<T>),
+                } as &'static BytesVt as *const BytesVt
+                    as *mut BytesVt)
             },
+            marker: core::marker::PhantomData,
         }
     }
 }
@@ -330,10 +492,14 @@ impl From<alloc::boxed::Box<[u8]>> for Bytes<'_> {
             len,
             capacity: len,
             data,
-            vtable: &BytesVt {
-                release: Some(release_box_bytes),
-                retain: None,
+            vtable: unsafe {
+                NonNull::new_unchecked(&BytesVt {
+                    release: Some(release_box_bytes),
+                    retain: None,
+                } as &'static BytesVt as *const BytesVt
+                    as *mut BytesVt)
             },
+            marker: core::marker::PhantomData,
         }
     }
 }
@@ -385,7 +551,10 @@ impl From<stabby::sync::ArcSlice<u8>> for Bytes<'static> {
                 len,
                 data: core::mem::transmute(data.start),
                 capacity: core::mem::transmute(data.end),
-                vtable: &STABBY_ARCSLICE_BYTESVT,
+                vtable: NonNull::new_unchecked(
+                    &STABBY_ARCSLICE_BYTESVT as &'static BytesVt as *const BytesVt as *mut BytesVt,
+                ),
+                marker: core::marker::PhantomData,
             }
         }
     }
@@ -410,10 +579,14 @@ impl<T: Sized + AsRef<[u8]> + Send + Sync + 'static> From<stabby::sync::Arc<T>> 
             len: data.len(),
             capacity: data.len(),
             data: unsafe { core::mem::transmute(stabby::sync::Arc::into_raw(value)) },
-            vtable: &BytesVt {
-                release: Some(release_stabby_arc::<T>),
-                retain: Some(retain_stabby_arc::<T>),
+            vtable: unsafe {
+                NonNull::new_unchecked(&BytesVt {
+                    release: Some(release_stabby_arc::<T>),
+                    retain: Some(retain_stabby_arc::<T>),
+                } as &'static BytesVt as *const BytesVt
+                    as *mut BytesVt)
             },
+            marker: core::marker::PhantomData,
         }
     }
 }
@@ -480,7 +653,7 @@ impl Clone for Bytes<'_> {
 }
 impl Drop for Bytes<'_> {
     fn drop(&mut self) {
-        if let Some(release) = self.vtable.release {
+        if let Some(release) = self.vtable().and_then(|vt| vt.release) {
             unsafe { release(self.data, self.capacity) }
         }
     }
@@ -499,7 +672,10 @@ impl<'a> TryFrom<Bytes<'a>> for Arc<[u8]> {
     type Error = Bytes<'a>;
     fn try_from(value: Bytes<'a>) -> Result<Self, Self::Error> {
         let data = value.data.cast();
-        match core::ptr::eq(value.vtable, &ARC_BYTES_VT)
+        let Some(vtable) = value.vtable() else {
+            return Err(value);
+        };
+        match core::ptr::eq(vtable, &ARC_BYTES_VT)
             && core::ptr::eq(value.start, data)
             && value.len == value.capacity
         {
@@ -526,7 +702,10 @@ impl<'a> TryFrom<Bytes<'a>> for stabby::sync::ArcSlice<u8> {
     type Error = Bytes<'a>;
     fn try_from(value: Bytes<'a>) -> Result<Self, Self::Error> {
         let data = value.data.cast();
-        match core::ptr::eq(value.vtable, &STABBY_ARCSLICE_BYTESVT) && core::ptr::eq(value.start, data) {
+        let Some(vtable) = value.vtable() else {
+            return Err(value);
+        };
+        match core::ptr::eq(vtable, &STABBY_ARCSLICE_BYTESVT) && core::ptr::eq(value.start, data) {
             true => unsafe {
                 let value = core::mem::ManuallyDrop::new(value);
                 let arc = stabby::sync::ArcSlice::from_raw(stabby::alloc::AllocSlice {

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -15,7 +15,7 @@ use safer_ffi_proc_macros::derive_ReprC;
 ///
 /// Typically, [`Bytes`] can constructed from `&'static [u8]`, `Arc<[u8]>` or `Arc<T: AsRef<[u8]>>`.
 ///
-/// [`Bytes`] can also "inlin" small enough slices: that is, if the slice is more than one byte smaller than
+/// [`Bytes`] can also "inline" small enough slices: that is, if the slice is more than one byte smaller than
 /// [`Bytes`] memory layout (which is 40 bytes on 64bit architectures), it may be store directly in that memory
 /// instead of through indirection.
 #[derive_ReprC]
@@ -59,7 +59,7 @@ const _: () = {
 
 extern "C" fn noop(_: *const (), _: usize) {}
 
-const IS_LITTLE_ENDIAN: bool = unsafe { mem::transmute::<u16, [bool; 2]>(1)[0] };
+const IS_LITTLE_ENDIAN: bool = cfg!(target_endian = "little");
 
 impl<'a> Bytes<'a> {
     /// Constructs an empty slice.
@@ -103,7 +103,7 @@ impl<'a> Bytes<'a> {
     /// This is equivalent to `<Bytes as From<&'static [u8]>>::from`, guaranteeing that [`Self::upgrade`] won't need to reallocate to recover the `'static` lifetime through [`Bytes::upgrade`].
     /// ```
     /// # use safer_ffi::bytes::Bytes;
-    /// let data = "Hello there, this string is long enough that it'll cross the inline-threshold (mem::size_of::<Bytes>() - 1) on all supported platforms";
+    /// let data = "Hello there, this string is long enough that it'll cross the inline-threshold (core::mem::size_of::<Bytes>() - 1) on all supported platforms";
     /// let mut bytes = Bytes::from_static(data.as_bytes());
     /// assert!(!bytes.upgrade_will_allocate());
     /// ```


### PR DESCRIPTION
The last bit of the memory layout is the determinant for interning:
- If it's unset, the layout is as expressed from the `struct` definition, and the pointer is guaranteed to be a valid reference to a vtable. No legal reference to a vtable can set this bit, as it would infringe on alignment constraints.
- If the bit is set, the layout is interned: the last byte (shifted by 1) is used as the length of the slice, and the slice starts at the first byte of the memory layout.

Interning lets us have cheap copies and lifetime upgrades for small slices (up to 39 bytes on 64bit archs), as copying them no longer requires an allocation if their original storage doesn't support reference counting or lifetime extension.

This PR also:
- Removes `From` for non-static slices, so that `From` and `from_static` are now equivalent, and `from_slice` is now the constructor from borrowed slices. The reasoning behind this is to make the more wasteful variant less ergonomic
- Adds constructors `From` `&'static [u8;N]` and `&'static str` to reduce boilerplate.