### PR TITLE
Fix Bytes serde support + add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,7 @@ dependencies = [
  "safer_ffi-proc_macros",
  "scopeguard",
  "serde",
+ "serde_test",
  "stabby",
  "tokio",
  "uninit",
@@ -707,6 +708,15 @@ checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.177"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed"
+dependencies = [
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docs)'] }
 safer-ffi.path = "."
 safer-ffi.features = ["internal-tests"]
 rand = "0.8.5"
+serde_test = { version = "1.0.177" }
 
 [dependencies]
 async-compat.optional = true
@@ -111,7 +112,7 @@ paste.version = "1.0.12"
 scopeguard.version = "1.1.0"
 scopeguard.default-features = false
 
-serde.version = "1.0.204"
+serde.version = "1.0.171"
 serde.optional = true
 serde.default-features = false
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -839,6 +839,19 @@ impl<'de> serde::de::Visitor<'de> for BytesVisitor {
     fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E> {
         Ok(Bytes::from_slice(v))
     }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let mut buf = Vec::with_capacity(seq.size_hint().unwrap_or(64));
+
+        while let Some(c) = seq.next_element::<u8>()? {
+            buf.push(c);
+        }
+
+        Ok(Bytes::from(buf))
+    }
 }
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
- Relaxes the serde version required to match the monorepo
- Adds tests using `serde_test` for Bytes ser/de operations