### PR TITLE
use correct framework

### DIFF
--- a/ffi_tests/tests/csharp/Tests.csproj
+++ b/ffi_tests/tests/csharp/Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
    </PropertyGroup>
 


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks