### PR TITLE
Tweaks to `repr_c::Arc`

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -13,8 +13,8 @@ ReprC! {
 impl<T> From<rust::Arc<T>> for Arc_<T> {
     #[inline]
     fn from(arced: rust::Arc<T>) -> Arc_<T> {
-        let raw = rust::Arc::into_raw(arced);
-        Self(ptr::NonNull::from(unsafe { &*raw }).into())
+        let raw = rust::Arc::into_raw(arced) as *mut T;
+        Self(unsafe { ptr::NonNull::new_unchecked(raw) }.into())
     }
 }
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -53,7 +53,7 @@ unsafe impl<T> Send for Arc_<T> where rust::Arc<T>: Send {}
 
 unsafe impl<T> Sync for Arc_<T> where rust::Arc<T>: Sync {}
 
-impl<T: Clone> Clone for Arc_<T> {
+impl<T> Clone for Arc_<T> {
     #[inline]
     fn clone(self: &'_ Self) -> Self {
         let raw = self.0.as_ptr() as *mut T;


### PR DESCRIPTION
Don't require that the type inside Arc_ implements Clone for Arc_ to implement
Clone.

---

Fix (at least part of!) the borrow-related issue as described here:

- https://github.com/getditto/safer_ffi/pull/254#discussion_r2035754508
