### PR TITLE
Improve handling of JS arrays

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -4,7 +4,7 @@ use ::core::slice;
 use crate::slice::*;
 
 ReprC! {
-    #[repr(C, js)]
+    #[repr(C)]
     #[cfg_attr(all(docs, feature = "nightly"), doc(cfg(feature = "alloc")))]
     /// Same as [`Vec<T>`][`rust::Vec`], but with guaranteed `#[repr(C)]` layout
     pub


### PR DESCRIPTION
Instead of sending vecs across to JS consumers as objects with `ptr`, `len`, and `cap` fields we now send across "proper" JS arrays. Similarly, when receiving a JS array we now expect it to be a "proper" JS array.