### PR TITLE
feat: add alloc-tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +35,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide 0.7.4",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -126,7 +150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
 ]
 
 [[package]]
@@ -235,20 +259,26 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "gloo-utils"
@@ -329,6 +359,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +404,15 @@ name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -470,10 +519,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.17.1"
+name = "object"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "paste"
@@ -605,7 +686,16 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -663,6 +753,12 @@ name = "run-sh"
 version = "0.0.0"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +796,7 @@ name = "safer-ffi"
 version = "0.2.0-alpha.0"
 dependencies = [
  "async-compat",
+ "backtrace",
  "cratesio-placeholder-package",
  "extern-c",
  "futures",
@@ -717,6 +814,7 @@ dependencies = [
  "seal-the-deal",
  "serde",
  "serde_test",
+ "serial_test",
  "stabby",
  "tokio",
  "uninit",
@@ -743,6 +841,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +864,12 @@ dependencies = [
  "ring 0.16.20",
  "untrusted 0.7.1",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seal-the-deal"
@@ -825,6 +938,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "sha2-const-stable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +982,12 @@ checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spin"
@@ -1040,12 +1184,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1318,13 +1462,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "with_builtin_macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ nightly = []
 alloc = []
 std = ["alloc", "scopeguard/use_std", "stabby?/std"]
 
+alloc-tracking = ["alloc", "backtrace"]
+
 async-fn = ["safer_ffi-proc_macros/async-fn"]
 
 debug_proc_macros = ["safer_ffi-proc_macros/verbose-expansions"]
@@ -82,10 +84,14 @@ safer-ffi.path = "."
 safer-ffi.features = ["internal-tests"]
 rand = "0.9.0"
 serde_test = { version = "1.0.177" }
+serial_test = "3.0"
 
 [dependencies]
 async-compat.optional = true
 async-compat.version = "0.2.1"
+
+backtrace.optional = true
+backtrace.version = "0.3"
 
 extern-c.version = "0.1.0"
 

--- a/src/_lib.rs
+++ b/src/_lib.rs
@@ -300,6 +300,9 @@ cfg_alloc! {
 #[cfg(feature = "alloc")]
 pub mod vec;
 
+#[cfg(feature = "alloc-tracking")]
+pub mod alloc_tracking;
+
 #[doc(inline)]
 pub use layout::impls::c_int;
 

--- a/src/alloc_tracking.rs
+++ b/src/alloc_tracking.rs
@@ -1,0 +1,393 @@
+#![cfg(feature = "alloc-tracking")]
+
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::sync::LazyLock;
+use std::sync::Mutex;
+
+use backtrace::Backtrace;
+
+#[derive(Debug, Clone)]
+pub struct AllocInfo {
+    pub type_name: &'static str,
+    pub alloc_backtrace: Backtrace,
+    pub free_backtrace: Option<Backtrace>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ArcInfo {
+    pub type_name: &'static str,
+    pub initial_alloc_backtrace: Backtrace,
+    pub ref_count: usize,
+    pub clone_backtraces: Vec<Backtrace>,
+    pub drop_backtraces: Vec<Backtrace>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct AllocationTracker {
+    // Regular allocations (Box, Vec, etc.)
+    regular_allocs: HashMap<usize, AllocInfo>,
+    // Arc allocations with ref counting
+    arc_allocs: HashMap<usize, ArcInfo>,
+}
+
+pub static ALLOC_TRACKER: LazyLock<Mutex<AllocationTracker>> = LazyLock::new(<_>::default);
+
+impl AllocationTracker {
+    // Regular allocation methods
+    #[track_caller]
+    pub fn track_alloc<T>(addr: *const T) {
+        let mut tracker = ALLOC_TRACKER.lock().unwrap();
+        tracker.regular_allocs.insert(
+            addr as usize,
+            AllocInfo {
+                type_name: ::core::any::type_name::<T>(),
+                alloc_backtrace: Backtrace::new_unresolved(),
+                free_backtrace: None,
+            },
+        );
+    }
+
+    #[track_caller]
+    pub fn track_free<T>(addr: *const T) {
+        let mut tracker = ALLOC_TRACKER.lock().unwrap();
+        match tracker.regular_allocs.get_mut(&(addr as usize)) {
+            | Some(&mut AllocInfo {
+                free_backtrace: ref mut free_backtrace @ None,
+                ..
+            }) => {
+                // OK, found entry
+                *free_backtrace = Some(Backtrace::new_unresolved());
+            },
+            | Some(AllocInfo {
+                free_backtrace: Some(free_backtrace),
+                alloc_backtrace,
+                type_name,
+            }) => {
+                alloc_backtrace.resolve();
+                free_backtrace.resolve();
+                let second_free_backtrace = Backtrace::new();
+                panic!(
+                    "\
+                        Error, double free of pointer {addr:p} pointing to type `{type_name}`\n\
+                        > It was allocated at\n{alloc_backtrace:?}.\n\
+                        \n\
+                        > It was (first) deallocated at\n{free_backtrace:?}.\n\
+                        \n\
+                        > A second deallocation attempt was made at\n{second_free_backtrace:?}.\
+                    ",
+                )
+            },
+            | None => panic!(
+                "\
+                    Error, pointer {addr:p} pointing to type `{type_name}` was \
+                    never allocated to begin with.\
+                ",
+                type_name = ::core::any::type_name::<T>(),
+            ),
+        }
+    }
+
+    // Arc-specific methods
+    #[track_caller]
+    pub fn track_arc_new<T>(addr: *const T) {
+        let mut tracker = ALLOC_TRACKER.lock().unwrap();
+        tracker.arc_allocs.insert(
+            addr as usize,
+            ArcInfo {
+                type_name: ::core::any::type_name::<T>(),
+                initial_alloc_backtrace: Backtrace::new_unresolved(),
+                ref_count: 1,
+                clone_backtraces: Vec::new(),
+                drop_backtraces: Vec::new(),
+            },
+        );
+    }
+
+    #[track_caller]
+    pub fn track_arc_clone<T>(addr: *const T) {
+        let mut tracker = ALLOC_TRACKER.lock().unwrap();
+        match tracker.arc_allocs.get_mut(&(addr as usize)) {
+            | Some(arc_info) => {
+                arc_info.ref_count += 1;
+                arc_info.clone_backtraces.push(Backtrace::new_unresolved());
+            },
+            | None => {
+                // First time seeing this Arc - assume it existed before
+                tracker.arc_allocs.insert(
+                    addr as usize,
+                    ArcInfo {
+                        type_name: ::core::any::type_name::<T>(),
+                        // this isn't actually the actual initial allocation backtrace, but it's the
+                        // best we can do here
+                        initial_alloc_backtrace: Backtrace::new_unresolved(),
+                        // we "guess" 2, the i.e. original allocation and this clone
+                        ref_count: 2,
+                        clone_backtraces: vec![Backtrace::new_unresolved()],
+                        drop_backtraces: Vec::new(),
+                    },
+                );
+            },
+        }
+    }
+
+    #[track_caller]
+    pub fn track_arc_drop<T>(addr: *const T) {
+        let mut tracker = ALLOC_TRACKER.lock().unwrap();
+        if let Some(arc_info) = tracker.arc_allocs.get_mut(&(addr as usize)) {
+            arc_info.ref_count = arc_info.ref_count.saturating_sub(1);
+            arc_info.drop_backtraces.push(Backtrace::new_unresolved());
+        }
+    }
+
+    // Unified snapshot ("regular" and arc)
+    pub fn snapshot() -> AllocationTracker {
+        ALLOC_TRACKER.lock().unwrap().clone()
+    }
+
+    // Combined comparison of all allocations
+    pub fn compare_to(
+        &mut self,
+        past: &mut AllocationTracker,
+    ) -> Result<(), String> {
+        let mut leaks = Vec::new();
+
+        // Check regular allocations
+        for (
+            addr,
+            AllocInfo {
+                free_backtrace,
+                alloc_backtrace,
+                type_name,
+            },
+        ) in &mut self.regular_allocs
+        {
+            let &addr = addr;
+            if free_backtrace.is_some() {
+                continue;
+            }
+            // Check if the allocation existed before the snapshot was taken
+            match past.regular_allocs.get_mut(&addr) {
+                | Some(AllocInfo {
+                    free_backtrace: None,
+                    ..
+                }) => {
+                    // OK - allocation existed before snapshot
+                },
+                | Some(AllocInfo {
+                    free_backtrace: Some(_),
+                    ..
+                }) => {
+                    // This shouldn't happen - freed in past but not freed now
+                    unreachable!()
+                },
+                // Otherwise, we have a leak!
+                | None => {
+                    alloc_backtrace.resolve();
+                    leaks.push(format!(
+                        "Memory leak! Pointer {addr:#x} pointing to type `{type_name}` was not freed!\n\
+                        Allocation origin:\n{alloc_backtrace:?}"
+                    ));
+                },
+            }
+        }
+
+        // Check Arc allocations
+        for (
+            addr,
+            ArcInfo {
+                ref_count,
+                type_name,
+                initial_alloc_backtrace,
+                clone_backtraces,
+                drop_backtraces,
+            },
+        ) in &mut self.arc_allocs
+        {
+            let &addr = addr;
+            if *ref_count == 0 {
+                continue; // Properly cleaned up
+            }
+
+            match past.arc_allocs.get(&addr) {
+                | Some(_) => {
+                    // OK - Arc existed before test
+                },
+                | None => {
+                    // Arc leak - created during test with remaining references
+                    initial_alloc_backtrace.resolve();
+
+                    let mut leak_msg = format!(
+                        "Arc leak! Pointer {addr:#x} of type `{type_name}` has {ref_count} remaining references\n\
+                        Initial allocation:\n{initial_alloc_backtrace:?}"
+                    );
+
+                    if !clone_backtraces.is_empty() {
+                        leak_msg.push_str("\n\nClone operations:");
+                        for (i, mut clone_bt) in clone_backtraces.iter().cloned().enumerate() {
+                            clone_bt.resolve();
+                            write!(leak_msg, "\nClone #{}: {clone_bt:?}", i + 1)
+                                .expect("String::write_fmt");
+                        }
+                    }
+
+                    if !drop_backtraces.is_empty() {
+                        leak_msg.push_str("\n\nDrop operations:");
+                        for (i, mut drop_bt) in drop_backtraces.iter().cloned().enumerate() {
+                            drop_bt.resolve();
+                            write!(leak_msg, "\nDrop #{}: {drop_bt:?}", i + 1)
+                                .expect("String::write_fmt");
+                        }
+                    }
+
+                    leaks.push(leak_msg);
+                },
+            }
+        }
+
+        if leaks.is_empty() {
+            Ok(())
+        } else {
+            Err(leaks.join("\n\n"))
+        }
+    }
+
+    pub fn reset() {
+        ::core::mem::take(&mut *ALLOC_TRACKER.lock().unwrap());
+    }
+
+    pub fn run(f: impl FnOnce()) -> Result<(), String> {
+        Self::reset();
+        f();
+        Self::snapshot().compare_to(&mut Self::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serial_test::serial;
+
+    use super::*;
+    use crate::arc::ThinArc;
+    use crate::boxed::ThinBox;
+
+    #[test]
+    #[serial]
+    fn test_no_leak() {
+        let res = AllocationTracker::run(|| {
+            let b = ThinBox::new(42i32);
+            drop(b);
+        });
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_memory_leak() {
+        let res = AllocationTracker::run(|| {
+            let b = ThinBox::new(42i32);
+            ::core::mem::forget(b);
+        });
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("Memory leak"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_arc_no_leak() {
+        let res = AllocationTracker::run(|| {
+            let arc = ThinArc::new(42i32);
+            drop(arc);
+        });
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_arc_clone_no_leak() {
+        let res = AllocationTracker::run(|| {
+            let arc1 = ThinArc::new(42i32);
+            let arc2 = arc1.clone();
+            let arc3 = arc2.clone();
+            drop(arc1);
+            drop(arc2);
+            drop(arc3);
+        });
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_arc_leak() {
+        let res = AllocationTracker::run(|| {
+            let arc = ThinArc::new(42i32);
+            ::core::mem::forget(arc);
+        });
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("Arc leak"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_arc_clone_leak() {
+        let res = AllocationTracker::run(|| {
+            let arc1 = ThinArc::new(42i32);
+            let arc2 = arc1.clone();
+            drop(arc1);
+            // arc2 is forgotten, should detect leak with ref count 1
+            ::core::mem::forget(arc2);
+        });
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("Arc leak"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_mixed_allocations_no_leak() {
+        let res = AllocationTracker::run(|| {
+            let box1 = ThinBox::new(42i32);
+            let box2 = ThinBox::new(String::from("test"));
+            let arc1 = ThinArc::new(100i32);
+            let arc2 = arc1.clone();
+            drop(box1);
+            drop(box2);
+            drop(arc1);
+            drop(arc2);
+        });
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_mixed_allocations_box_leak() {
+        let res = AllocationTracker::run(|| {
+            let box1 = ThinBox::new(42i32);
+            let arc1 = ThinArc::new(100i32);
+            let arc2 = arc1.clone();
+
+            // Properly clean up arcs but forget the box
+            ::core::mem::forget(box1);
+            drop(arc1);
+            drop(arc2);
+        });
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("Memory leak"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_mixed_allocations_arc_leak() {
+        let res = AllocationTracker::run(|| {
+            let box1 = ThinBox::new(42i32);
+            let arc1 = ThinArc::new(100i32);
+            let arc2 = arc1.clone();
+
+            // Properly clean up box but forget one arc
+            drop(box1);
+            drop(arc1);
+            ::core::mem::forget(arc2);
+        });
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("Arc leak"));
+    }
+}

--- a/src/alloc_tracking.rs
+++ b/src/alloc_tracking.rs
@@ -38,14 +38,11 @@ impl AllocationTracker {
     #[track_caller]
     pub fn track_alloc<T>(addr: *const T) {
         let mut tracker = ALLOC_TRACKER.lock().unwrap();
-        tracker.regular_allocs.insert(
-            addr as usize,
-            AllocInfo {
-                type_name: ::core::any::type_name::<T>(),
-                alloc_backtrace: Backtrace::new_unresolved(),
-                free_backtrace: None,
-            },
-        );
+        tracker.regular_allocs.insert(addr as usize, AllocInfo {
+            type_name: ::core::any::type_name::<T>(),
+            alloc_backtrace: Backtrace::new_unresolved(),
+            free_backtrace: None,
+        });
     }
 
     #[track_caller]
@@ -92,16 +89,13 @@ impl AllocationTracker {
     #[track_caller]
     pub fn track_arc_new<T>(addr: *const T) {
         let mut tracker = ALLOC_TRACKER.lock().unwrap();
-        tracker.arc_allocs.insert(
-            addr as usize,
-            ArcInfo {
-                type_name: ::core::any::type_name::<T>(),
-                initial_alloc_backtrace: Backtrace::new_unresolved(),
-                ref_count: 1,
-                clone_backtraces: Vec::new(),
-                drop_backtraces: Vec::new(),
-            },
-        );
+        tracker.arc_allocs.insert(addr as usize, ArcInfo {
+            type_name: ::core::any::type_name::<T>(),
+            initial_alloc_backtrace: Backtrace::new_unresolved(),
+            ref_count: 1,
+            clone_backtraces: Vec::new(),
+            drop_backtraces: Vec::new(),
+        });
     }
 
     #[track_caller]
@@ -114,19 +108,16 @@ impl AllocationTracker {
             },
             | None => {
                 // First time seeing this Arc - assume it existed before
-                tracker.arc_allocs.insert(
-                    addr as usize,
-                    ArcInfo {
-                        type_name: ::core::any::type_name::<T>(),
-                        // this isn't actually the actual initial allocation backtrace, but it's the
-                        // best we can do here
-                        initial_alloc_backtrace: Backtrace::new_unresolved(),
-                        // we "guess" 2, the i.e. original allocation and this clone
-                        ref_count: 2,
-                        clone_backtraces: vec![Backtrace::new_unresolved()],
-                        drop_backtraces: Vec::new(),
-                    },
-                );
+                tracker.arc_allocs.insert(addr as usize, ArcInfo {
+                    type_name: ::core::any::type_name::<T>(),
+                    // this isn't actually the actual initial allocation backtrace, but it's the
+                    // best we can do here
+                    initial_alloc_backtrace: Backtrace::new_unresolved(),
+                    // we "guess" 2, the i.e. original allocation and this clone
+                    ref_count: 2,
+                    clone_backtraces: vec![Backtrace::new_unresolved()],
+                    drop_backtraces: Vec::new(),
+                });
             },
         }
     }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -89,6 +89,8 @@ impl<T> From<rust::Arc<T>> for ThinArc<T> {
     #[inline]
     fn from(arced: rust::Arc<T>) -> Arc<T> {
         let raw = rust::Arc::into_raw(arced);
+        #[cfg(feature = "alloc-tracking")]
+        crate::alloc_tracking::AllocationTracker::track_arc_new(raw);
         Self(ptr::NonNull::new(raw.cast_mut()).unwrap().into())
     }
 }
@@ -102,6 +104,8 @@ impl<T> ThinArc<T> {
     #[inline]
     pub fn into(self: ThinArc<T>) -> rust::Arc<T> {
         let mut this = mem::ManuallyDrop::new(self);
+        #[cfg(feature = "alloc-tracking")]
+        crate::alloc_tracking::AllocationTracker::track_arc_drop(this.0.as_ptr());
         unsafe { rust::Arc::from_raw(this.0.as_mut_ptr()) }
     }
 
@@ -114,12 +118,17 @@ impl<T> ThinArc<T> {
     /// See [`rust::Arc<T>::into_raw()`].
     #[inline]
     pub fn into_raw(self) -> *const T {
-        Self::as_ptr(&*::core::mem::ManuallyDrop::new(self))
+        let this = core::mem::ManuallyDrop::new(self);
+        #[cfg(feature = "alloc-tracking")]
+        crate::alloc_tracking::AllocationTracker::track_arc_drop(this.0.as_ptr());
+        Self::as_ptr(&*this)
     }
 
     /// See [`rust::Arc<T>::from_raw()`].
     #[inline]
     pub unsafe fn from_raw(ptr: *const T) -> Self {
+        #[cfg(feature = "alloc-tracking")]
+        crate::alloc_tracking::AllocationTracker::track_arc_new(ptr);
         Self(unsafe { ptr::NonNull::new_unchecked(ptr.cast_mut()) }.into())
     }
 
@@ -155,6 +164,8 @@ impl<T> ThinArc<T> {
 impl<T> Drop for ThinArc<T> {
     #[inline]
     fn drop(self: &'_ mut ThinArc<T>) {
+        #[cfg(feature = "alloc-tracking")]
+        crate::alloc_tracking::AllocationTracker::track_arc_drop(self.0.as_ptr());
         unsafe {
             drop::<rust::Arc<T>>(rust::Arc::from_raw(self.0.as_mut_ptr()));
         }
@@ -177,7 +188,10 @@ unsafe impl<T> Sync for ThinArc<T> where rust::Arc<T>: Sync {}
 impl<T> Clone for ThinArc<T> {
     #[inline]
     fn clone(self: &'_ Self) -> Self {
-        self.with_rust(rust::Arc::clone).into()
+        let clone = self.with_rust(rust::Arc::clone).into();
+        #[cfg(feature = "alloc-tracking")]
+        crate::alloc_tracking::AllocationTracker::track_arc_clone(ThinArc::as_ptr(&clone));
+        clone
     }
 }
 

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -88,7 +88,10 @@ ReprC! {
 impl<T> From<rust::Box<T>> for ThinBox<T> {
     #[inline]
     fn from(boxed: rust::Box<T>) -> ThinBox<T> {
-        Self(ptr::NonNull::from(rust::Box::leak(boxed)).into())
+        let ptr = rust::Box::leak(boxed);
+        #[cfg(feature = "alloc-tracking")]
+        crate::alloc_tracking::AllocationTracker::track_alloc(ptr as *const T);
+        Self(ptr::NonNull::from(ptr).into())
     }
 }
 
@@ -101,6 +104,8 @@ impl<T> ThinBox<T> {
     #[inline]
     pub fn into(self: ThinBox<T>) -> rust::Box<T> {
         let mut this = mem::ManuallyDrop::new(self);
+        #[cfg(feature = "alloc-tracking")]
+        crate::alloc_tracking::AllocationTracker::track_free(this.0.as_ptr());
         unsafe { rust::Box::from_raw(this.0.as_mut_ptr()) }
     }
 }
@@ -108,6 +113,8 @@ impl<T> ThinBox<T> {
 impl<T> Drop for ThinBox<T> {
     #[inline]
     fn drop(self: &'_ mut ThinBox<T>) {
+        #[cfg(feature = "alloc-tracking")]
+        crate::alloc_tracking::AllocationTracker::track_free(self.0.as_ptr());
         unsafe {
             drop::<rust::Box<T>>(rust::Box::from_raw(self.0.as_mut_ptr()));
         }

--- a/src/char_p.rs
+++ b/src/char_p.rs
@@ -409,9 +409,12 @@ cfg_alloc! {
                     s.push(NUL as _);
                 }
                 let s: rust::Box<[u8]> = s.into_boxed_str().into();
+                let ptr = rust::Box::into_raw(s) as *mut u8;
+                #[cfg(feature = "alloc-tracking")]
+                crate::alloc_tracking::AllocationTracker::track_alloc(ptr);
                 unsafe {
                     Self::from_ptr_unchecked(
-                        ptr::NonNull::new(rust::Box::into_raw(s) as *mut u8)
+                        ptr::NonNull::new(ptr)
                             .unwrap()
                     )
                 }
@@ -426,6 +429,8 @@ cfg_alloc! {
                 if ptr::eq(self.0.as_mut_ptr().cast(), &EMPTY_SENTINEL) {
                     return;
                 }
+                #[cfg(feature = "alloc-tracking")]
+                crate::alloc_tracking::AllocationTracker::track_free(self.0.as_ptr().cast::<u8>());
                 let num_bytes = self.to_bytes_with_null().len();
                 drop::<rust::Box<[u8]>>(
                     rust::Box::from_raw(slice::from_raw_parts_mut(
@@ -495,6 +500,8 @@ cfg_alloc! {
             }
             let num_bytes = self.to_bytes_with_null().len();
             let ptr = mem::ManuallyDrop::new(self).0.as_mut_ptr();
+            #[cfg(feature = "alloc-tracking")]
+            crate::alloc_tracking::AllocationTracker::track_free(ptr.cast::<u8>());
             let boxed_bytes = unsafe {
                 rust::Box::from_raw(slice::from_raw_parts_mut(
                     ptr.cast(),
@@ -568,9 +575,12 @@ cfg_std! {
                 s   .into_bytes_with_nul()
                     .into_boxed_slice()
             ;
+            let s_ptr = rust::Box::leak(s).as_mut_ptr();
+            #[cfg(feature = "alloc-tracking")]
+            crate::alloc_tracking::AllocationTracker::track_alloc(s_ptr);
             unsafe {
                 Self::from_ptr_unchecked(
-                    ptr::NonNull::new(rust::Box::leak(s).as_mut_ptr())
+                    ptr::NonNull::new(s_ptr)
                         .unwrap()
                 )
             }

--- a/src/closure/arc.rs
+++ b/src/closure/arc.rs
@@ -117,16 +117,25 @@ macro_rules! with_tuple {(
         {
             // Safety: `F` can be "raw-coerced" to `dyn 'static + Send + Fn...`
             // thanks to the generic bounds on F.
+            let env_ptr = unsafe {
+                ptr::NonNull::new_unchecked(Arc::into_raw(f) as _)
+            };
+            #[cfg(feature = "alloc-tracking")]
+            crate::alloc_tracking::AllocationTracker::track_arc_new(
+                env_ptr.cast::<F>().as_ptr()
+            );
             Self {
-                env_ptr: unsafe {
-                    ptr::NonNull::new_unchecked(Arc::into_raw(f) as _)
-                },
+                env_ptr,
                 release: {
                     unsafe extern "C"
                     fn release<F> (env_ptr: ptr::NonNull<c_void>)
                     where
                         F : Send + Sync + 'static,
                     {
+                        #[cfg(feature = "alloc-tracking")]
+                        crate::alloc_tracking::AllocationTracker::track_arc_drop(
+                            env_ptr.cast::<F>().as_ptr()
+                        );
                         unsafe {
                             drop::<Arc<F>>(Arc::from_raw(env_ptr.cast().as_ptr()));
                         }
@@ -139,6 +148,10 @@ macro_rules! with_tuple {(
                     where
                         F : Send + Sync + 'static,
                     {
+                        #[cfg(feature = "alloc-tracking")]
+                        crate::alloc_tracking::AllocationTracker::track_arc_clone(
+                            env_ptr.cast::<F>().as_ptr()
+                        );
                         mem::forget(Arc::<F>::clone(&
                             mem::ManuallyDrop::new(unsafe {
                                 Arc::from_raw(env_ptr.cast().as_ptr())
@@ -295,4 +308,86 @@ with_tuples! {
 with_tuples! {
     ArcDynFn0,
     (ArcDynFn1, A1),
+}
+
+#[cfg(all(test, feature = "alloc-tracking"))]
+mod tests {
+    use serial_test::serial;
+
+    use super::*;
+    use crate::alloc_tracking::AllocationTracker;
+
+    #[test]
+    #[serial]
+    fn test_arc_closure_no_leak() {
+        let res = AllocationTracker::run(|| {
+            let closure = ArcDynFn0::new(Arc::new(|| {}));
+            drop(closure);
+        });
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_arc_closure_with_args_no_leak() {
+        let res = AllocationTracker::run(|| {
+            let closure = ArcDynFn1::new(Arc::new(|x: i32| x + 1));
+            let result = closure.call(41);
+            assert_eq!(result, 42);
+            drop(closure);
+        });
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_arc_closure_clone_no_leak() {
+        let res = AllocationTracker::run(|| {
+            let closure1 = ArcDynFn0::new(Arc::new(|| {}));
+            let closure2 = closure1.clone();
+            let closure3 = closure2.clone();
+            drop(closure1);
+            drop(closure2);
+            drop(closure3);
+        });
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_arc_closure_leak() {
+        let res = AllocationTracker::run(|| {
+            let closure = ArcDynFn0::new(Arc::new(|| {}));
+            ::core::mem::forget(closure);
+        });
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("Arc leak"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_arc_closure_clone_leak() {
+        let res = AllocationTracker::run(|| {
+            let closure1 = ArcDynFn0::new(Arc::new(|| {}));
+            let closure2 = closure1.clone();
+            drop(closure1);
+            // closure2 is forgotten, should detect leak with ref count 1
+            ::core::mem::forget(closure2);
+        });
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("Arc leak"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_arc_closure_with_capture_no_leak() {
+        let res = AllocationTracker::run(|| {
+            let captured = String::from("hello");
+            let closure = ArcDynFn0::new(Arc::new(move || captured.len()));
+            let result = closure.call();
+            assert_eq!(result, 5);
+            drop(closure);
+        });
+        assert!(res.is_ok());
+    }
 }

--- a/src/closure/boxed.rs
+++ b/src/closure/boxed.rs
@@ -113,9 +113,18 @@ macro_rules! with_tuple {(
         {
             // Safety: `F` can be "raw-coerced" to `dyn 'static + Send + FnMut...`
             // thanks to the generic bounds on F.
+            let env_ptr = ptr::NonNull::from(Box::leak(f)).cast();
+            #[cfg(feature = "alloc-tracking")]
+            crate::alloc_tracking::AllocationTracker::track_alloc(
+                env_ptr.cast::<F>().as_ptr()
+            );
             Self {
-                env_ptr: ptr::NonNull::from(Box::leak(f)).cast(),
+                env_ptr,
                 free: Some(::extern_c::extern_c(|env_ptr: ptr::NonNull<c_void>| unsafe {
+                    #[cfg(feature = "alloc-tracking")]
+                    crate::alloc_tracking::AllocationTracker::track_free(
+                        env_ptr.cast::<F>().as_ptr()
+                    );
                     drop(Box::<F>::from_raw(env_ptr.cast().as_ptr()));
                 })),
                 call: Some(::extern_c::extern_c(
@@ -236,4 +245,59 @@ with_tuples! {
 with_tuples! {
     BoxDynFnMut0,
     (BoxDynFnMut1, A1),
+}
+
+#[cfg(all(test, feature = "alloc-tracking"))]
+mod tests {
+    use serial_test::serial;
+
+    use super::*;
+    use crate::alloc_tracking::AllocationTracker;
+
+    #[test]
+    #[serial]
+    fn test_boxed_closure_no_leak() {
+        let res = AllocationTracker::run(|| {
+            let mut closure = BoxDynFnMut0::new(Box::new(|| {}));
+            closure.call();
+            drop(closure);
+        });
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_boxed_closure_with_args_no_leak() {
+        let res = AllocationTracker::run(|| {
+            let mut closure = BoxDynFnMut1::new(Box::new(|x: i32| x + 1));
+            let result = closure.call(41);
+            assert_eq!(result, 42);
+            drop(closure);
+        });
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn test_boxed_closure_leak() {
+        let res = AllocationTracker::run(|| {
+            let closure = BoxDynFnMut0::new(Box::new(|| 42i32));
+            ::core::mem::forget(closure);
+        });
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("Memory leak"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_boxed_closure_with_capture_no_leak() {
+        let res = AllocationTracker::run(|| {
+            let char_p = char_p::new("hello");
+            let mut closure = BoxDynFnMut0::new(Box::new(move || char_p.to_str().len()));
+            let result = closure.call();
+            assert_eq!(result, 5);
+            drop(closure);
+        });
+        assert!(res.is_ok());
+    }
 }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -161,12 +161,16 @@ cfg_alloc! {
         fn from (boxed_slice: rust::Box<[T]>)
           -> Self
         {
+            let len = boxed_slice.len();
+            let ptr = rust::Box::leak(boxed_slice).as_mut_ptr();
+            #[cfg(feature = "alloc-tracking")]
+            if len != 0 && mem::size_of::<T>() != 0 {
+                crate::alloc_tracking::AllocationTracker::track_alloc(ptr);
+            }
             slice_boxed {
-                len: boxed_slice.len(),
+                len,
                 ptr: unsafe {
-                    ptr::NonNull::new_unchecked(
-                        rust::Box::leak(boxed_slice).as_mut_ptr()
-                    )
+                    ptr::NonNull::new_unchecked(ptr)
                 }.into(),
             }
         }
@@ -179,6 +183,10 @@ cfg_alloc! {
           -> rust::Box<[T]>
         {
             let mut this = mem::ManuallyDrop::new(value);
+            #[cfg(feature = "alloc-tracking")]
+            if this.len != 0 && mem::size_of::<T>() != 0 {
+                crate::alloc_tracking::AllocationTracker::track_free(this.ptr.as_ptr());
+            }
             unsafe {
                 rust::Box::from_raw(
                     slice::from_raw_parts_mut(
@@ -196,6 +204,10 @@ cfg_alloc! {
         #[inline]
         fn drop (self: &'_ mut Self)
         {
+            #[cfg(feature = "alloc-tracking")]
+            if self.len != 0 && mem::size_of::<T>() != 0 {
+                crate::alloc_tracking::AllocationTracker::track_free(self.ptr.as_ptr());
+            }
             unsafe {
                 drop::<rust::Box<[T]>>(
                     rust::Box::from_raw(

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -47,6 +47,10 @@ impl<T> From<rust::Vec<T>> for Vec<T> {
         let len = vec.len();
         let cap = vec.capacity();
         let ptr = mem::ManuallyDrop::new(vec).as_mut_ptr();
+        #[cfg(feature = "alloc-tracking")]
+        if cap != 0 {
+            crate::alloc_tracking::AllocationTracker::track_alloc(ptr);
+        }
         Self {
             ptr: unsafe {
                 // Safety: `Vec` guarantees its pointer is nonnull.
@@ -64,6 +68,10 @@ impl<T> From<Vec<T>> for rust::Vec<T> {
     #[inline]
     fn from(value: Vec<T>) -> rust::Vec<T> {
         let mut this = mem::ManuallyDrop::new(value);
+        #[cfg(feature = "alloc-tracking")]
+        if this.cap != 0 {
+            crate::alloc_tracking::AllocationTracker::track_free(this.ptr.as_ptr());
+        }
         unsafe {
             // Safety: pointers originate from `Vec`.
             rust::Vec::from_raw_parts(this.ptr.as_mut_ptr(), this.len, this.cap)
@@ -74,11 +82,12 @@ impl<T> From<Vec<T>> for rust::Vec<T> {
 impl<T> Drop for Vec<T> {
     #[inline]
     fn drop(self: &'_ mut Vec<T>) {
+        #[cfg(feature = "alloc-tracking")]
+        if self.cap != 0 {
+            crate::alloc_tracking::AllocationTracker::track_free(self.ptr.as_ptr());
+        }
         unsafe {
-            drop::<rust::Vec<T>>(
-                ptr::read(self) // ManuallyDrop::take()
-                    .into(),
-            )
+            let _ = rust::Vec::from_raw_parts(self.ptr.as_mut_ptr(), self.len, self.cap);
         }
     }
 }


### PR DESCRIPTION
Resolves SDKS-1896
Extracted from getditto/ditto#18937

## Summary

Adds an opt-in `alloc-tracking` Cargo feature that records allocation, deallocation, and Arc clone/drop events with backtraces to help diagnose use-after-free, double-free, and Arc refcount bugs in FFI code.

## Changes

- New `alloc-tracking` feature (off by default) gated on a new optional `backtrace` dependency
- New `src/alloc_tracking.rs` module exposing `AllocationTracker` with:
  - `track_alloc` / `track_free` for `Box`/`Vec`/`slice`/`char_p` allocations (double-free and unknown-pointer-free panics)
  - `track_arc_new` / `track_arc_clone` / `track_arc_drop` for `Arc` refcount events
  - Global `ALLOC_TRACKER` behind a `LazyLock<Mutex<…>>`
- Instrumented the following types with feature-gated hooks on construction, clone, and drop paths:
  - `ThinArc` (`src/arc.rs`)
  - `ThinBox` (`src/boxed.rs`)
  - `char_p::Box` / `CString` conversions (`src/char_p.rs`)
  - `slice_boxed` (`src/slice.rs`), skipping zero-length and ZST allocations
  - `Vec` FFI wrapper (`src/vec.rs`)
  - Closure `Arc`/`Box` wrappers (`src/closure/arc.rs`, `src/closure/boxed.rs`)
- Added `serial_test` dev-dependency (tracker state is global, so tests must not run in parallel)

## Notes

All instrumentation is behind `#[cfg(feature = "alloc-tracking")]` and has zero runtime cost when the feature is disabled.

`cargo check --all-features` does **not** work on this branch or on `master` — it activates the `nightly` feature (which requires a nightly toolchain) and hits a pre-existing serde `visit_byte_buf` mismatch in `src/bytes.rs`. Use the targeted commands below instead.

## Test plan

- [x] `cargo check --features alloc-tracking`
- [x] `cargo test --features alloc-tracking`
- [x] `cargo check` (default features, verify no regression from feature-gating)