### PR TITLE
csharp: emit `struct` field `bool` as `byte` to keep structs blittable

### DIFF
--- a/src/headers/languages/csharp.rs
+++ b/src/headers/languages/csharp.rs
@@ -216,15 +216,23 @@ impl HeaderLanguage for CSharp {
                     out!("\n");
                 }
                 this.emit_docs(ctx, docs, indent)?;
-                if let Some(CSharpMarshaler(csharp_marshaler)) = field_ty.metadata().dyn_request() {
-                    out!((
-                        "[MarshalAs({csharp_marshaler})]"
-                    ));
+                // Struct-field bools are emitted as `byte`, not
+                // `[MarshalAs(UnmanagedType.U1)] bool`: the attribute makes the
+                // struct non-blittable, which netfx P/Invoke rejects for
+                // by-value args/returns. Callers convert at the use site.
+                if field_ty.short_name() == "bool" {
+                    out!(("public byte {name};"));
+                } else {
+                    if let Some(CSharpMarshaler(csharp_marshaler)) = field_ty.metadata().dyn_request() {
+                        out!((
+                            "[MarshalAs({csharp_marshaler})]"
+                        ));
+                    }
+                    out!(
+                        ("public {};"),
+                        F(|out| field_ty.render_wrapping_var(out, this, Some(&name))),
+                    );
                 }
-                out!(
-                    ("public {};"),
-                    F(|out| field_ty.render_wrapping_var(out, this, Some(&name))),
-                );
             }
         }
         out!(("}}"));
@@ -454,7 +462,8 @@ impl HeaderLanguage for CSharp {
             let elem_ty_name = elem_ty.name(this);
             #[rustfmt::skip]
             const FIXED_ARRAY_COMPATIBLE_TYPE_NAMES: &[&str] = &[
-                "bool",
+                // `bool` excluded: C# `fixed` rejects it, and bool arrays
+                // need `byte` substitution for netfx blittability (see `declare_struct`).
                 "byte", "UInt8", "UInt16", "UInt32", "UInt64", "UIntPtr",
                 "sbyte", "Int8", "Int16", "Int32", "Int64", "IntPtr",
                 "float", "double",
@@ -469,16 +478,22 @@ impl HeaderLanguage for CSharp {
             } else {
                 // Sadly for the general case fixed arrays are
                 // not supported.
+                let elem_is_bool = elem_ty.short_name() == "bool";
                 for i in 0..array_len {
-                    write!(
-                        out,
-                        "    {marshaler}public {elem_ty_name} _{i};\n",
-                        marshaler = elem_ty
-                            .metadata()
-                            .dyn_request::<CSharpMarshaler>()
-                            .unwrap_or_default()
-                            .pretty_print("[MarshalAs(", ")]\n    "),
-                    )?;
+                    if elem_is_bool {
+                        // Same `byte`-for-bool substitution as in `declare_struct`.
+                        write!(out, "    public byte _{i};\n")?;
+                    } else {
+                        write!(
+                            out,
+                            "    {marshaler}public {elem_ty_name} _{i};\n",
+                            marshaler = elem_ty
+                                .metadata()
+                                .dyn_request::<CSharpMarshaler>()
+                                .unwrap_or_default()
+                                .pretty_print("[MarshalAs(", ")]\n    "),
+                        )?;
+                    }
                 }
             }
             Ok(())

--- a/src/headers/languages/csharp.rs
+++ b/src/headers/languages/csharp.rs
@@ -223,7 +223,9 @@ impl HeaderLanguage for CSharp {
                 if field_ty.short_name() == "bool" {
                     out!(("public byte {name};"));
                 } else {
-                    if let Some(CSharpMarshaler(csharp_marshaler)) = field_ty.metadata().dyn_request() {
+                    if let Some(CSharpMarshaler(csharp_marshaler)) =
+                        field_ty.metadata().dyn_request()
+                    {
                         out!((
                             "[MarshalAs({csharp_marshaler})]"
                         ));


### PR DESCRIPTION
Closes SDKS-3249

Our current C# generation produces structs with boolean fields:

```
[StructLayout(LayoutKind.Sequential, Size = 16)]
public unsafe struct dittoffi_store_begin_transaction_options_t {
    /// <summary>
    /// Whether the transaction is read-only. Defaults to <c>false</c>.
    /// </summary>
    [MarshalAs(UnmanagedType.U1)] <<<<<<<<<<<<<<=============== 👈👈  
    public bool is_read_only;     <<<<<<<<<<<<<<=============== This needs to be `byte` 

    /// <summary>
    /// An optional hint for the transaction. This is often useful for identifying a transaction in
    /// logs.
    /// </summary>
    public byte /*const*/ * hint;
}
```

Which are not blittable. .NET 6 accepted this, but as we want to target .NET Framework 4.8, this isn't compatible and it'll fail at runtime with: `MarshalDirectiveException: Method's type signature is not PInvoke compatible at the first invocation`


This should now be:

```
[StructLayout(LayoutKind.Sequential, Size = 16)]
public unsafe struct dittoffi_store_begin_transaction_options_t {
    /// <summary>
    /// Whether the transaction is read-only. Defaults to <c>false</c>.
    /// </summary>
    public byte is_read_only;

    /// <summary>
    /// An optional hint for the transaction. This is often useful for identifying a transaction in
    /// logs.
    /// </summary>
    public byte /*const*/ * hint;
}
```

And interpreted accordingly at the SDK level. 