### PR TITLE
feat: implement `Default` trait for `ThinBox`, `TaggedOption`, `Vec` and `String`

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -130,6 +130,12 @@ impl<T> DerefMut for ThinBox<T> {
     }
 }
 
+impl<T: Default> Default for ThinBox<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
 unsafe impl<T> Send for ThinBox<T> where rust::Box<T>: Send {}
 
 unsafe impl<T> Sync for ThinBox<T> where rust::Box<T>: Sync {}

--- a/src/option.rs
+++ b/src/option.rs
@@ -122,6 +122,12 @@ impl<T> TaggedOption<T> {
     }
 }
 
+impl<T> Default for TaggedOption<T> {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
 #[test]
 fn option() {
     use crate::layout::ReprC;

--- a/src/string/_mod.rs
+++ b/src/string/_mod.rs
@@ -122,4 +122,10 @@ cfg_alloc! {
             Self(self.0.clone())
         }
     }
+
+    impl Default for String {
+        fn default() -> Self{
+            Self::EMPTY
+        }
+    }
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -97,6 +97,12 @@ impl<T> DerefMut for Vec<T> {
     }
 }
 
+impl<T> Default for Vec<T> {
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
 unsafe impl<T> Send for Vec<T> where rust::Vec<T>: Send {}
 
 unsafe impl<T> Sync for Vec<T> where rust::Vec<T>: Sync {}


### PR DESCRIPTION
Add `Default` implementations for `ThinBox`, `TaggedOption`, `Vec`, and `String` types to improves ergonomics and compatibility while matching the behavior of `Box<T>`,`Option<T>`,`Vec<T>` and `String` whose default value are `Box::new()`, `None`, `Vec::new()` and `String::from("")` respectively